### PR TITLE
Mekle Patricia Trie Cache

### DIFF
--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -113,12 +113,12 @@ defmodule Blockchain.Account do
   ## Examples
 
       iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
-      ...> |> MerklePatriciaTree.Trie.update(<<0x01::160>> |> ExthCrypto.Hash.Keccak.kec(), ExRLP.encode([5, 6, <<1>>, <<2>>]))
+      ...> |> MerklePatriciaTree.Trie.update_key(<<0x01::160>> |> ExthCrypto.Hash.Keccak.kec(), ExRLP.encode([5, 6, <<1>>, <<2>>]))
       ...> |> Blockchain.Account.get_account(<<0x01::160>>)
       %Blockchain.Account{nonce: 5, balance: 6, storage_root: <<0x01>>, code_hash: <<0x02>>}
 
       iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
-      ...> |> MerklePatriciaTree.Trie.update(<<0x01::160>> |> ExthCrypto.Hash.Keccak.kec(), nil)
+      ...> |> MerklePatriciaTree.Trie.update_key(<<0x01::160>> |> ExthCrypto.Hash.Keccak.kec(), nil)
       ...> |> Blockchain.Account.get_account(<<0x01::160>>)
       nil
 
@@ -128,7 +128,7 @@ defmodule Blockchain.Account do
   """
   @spec get_account(Trie.t(), Address.t()) :: t | nil
   def get_account(state, address) do
-    trie = Trie.get(state, Keccak.kec(address))
+    trie = Trie.get_key(state, Keccak.kec(address))
 
     case trie do
       nil ->
@@ -168,7 +168,7 @@ defmodule Blockchain.Account do
 
   ## Examples
 
-      iex> state = MerklePatriciaTree.Trie.update(MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db()), <<0x01::160>> |> ExthCrypto.Hash.Keccak.kec(), ExRLP.encode([5, 6, <<1>>, <<2>>]))
+      iex> state = MerklePatriciaTree.Trie.update_key(MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db()), <<0x01::160>> |> ExthCrypto.Hash.Keccak.kec(), ExRLP.encode([5, 6, <<1>>, <<2>>]))
       iex> Blockchain.Account.get_accounts(state, [<<0x01::160>>, <<0x02::160>>])
       [
         %Blockchain.Account{nonce: 5, balance: 6, storage_root: <<0x01>>, code_hash: <<0x02>>},
@@ -187,7 +187,7 @@ defmodule Blockchain.Account do
   ## Examples
 
       iex> state = Blockchain.Account.put_account(MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db()), <<0x01::160>>, %Blockchain.Account{nonce: 5, balance: 6, storage_root: <<0x01>>, code_hash: <<0x02>>})
-      iex> MerklePatriciaTree.Trie.get(state, <<0x01::160>> |> ExthCrypto.Hash.Keccak.kec()) |> ExRLP.decode
+      iex> MerklePatriciaTree.Trie.get_key(state, <<0x01::160>> |> ExthCrypto.Hash.Keccak.kec()) |> ExRLP.decode
       [<<5>>, <<6>>, <<0x01>>, <<0x02>>]
   """
   @spec put_account(EVM.state(), Address.t(), t) :: EVM.state()
@@ -197,7 +197,7 @@ defmodule Blockchain.Account do
       |> serialize()
       |> ExRLP.encode()
 
-    Trie.update(state, Keccak.kec(address), encoded_account)
+    Trie.update_key(state, Keccak.kec(address), encoded_account)
   end
 
   @doc """
@@ -227,7 +227,7 @@ defmodule Blockchain.Account do
         state
 
       _acc ->
-        Trie.remove(state, Keccak.kec(address))
+        Trie.remove_key(state, Keccak.kec(address))
     end
   end
 

--- a/apps/blockchain/lib/blockchain/account/repo.ex
+++ b/apps/blockchain/lib/blockchain/account/repo.ex
@@ -461,7 +461,7 @@ defmodule Blockchain.Account.Repo do
 
       iex> MerklePatriciaTree.Test.random_ets_db()
       ...> |> MerklePatriciaTree.Trie.new()
-      ...> |> MerklePatriciaTree.Trie.update(<<5>>, <<6>>)
+      ...> |> MerklePatriciaTree.Trie.update_key(<<5>>, <<6>>)
       ...> |> Blockchain.Account.Repo.new()
       ...> |> Blockchain.Account.Repo.dump_storage()
       %{<<5>> => <<6>>}

--- a/apps/blockchain/lib/blockchain/account/storage.ex
+++ b/apps/blockchain/lib/blockchain/account/storage.ex
@@ -18,7 +18,7 @@ defmodule Blockchain.Account.Storage do
 
     db
     |> Trie.new(root)
-    |> Trie.update(k, v)
+    |> Trie.update_key(k, v)
   end
 
   @spec remove(DB.db(), EVM.trie_root(), integer()) :: Trie.t()
@@ -27,7 +27,7 @@ defmodule Blockchain.Account.Storage do
 
     db
     |> Trie.new(root)
-    |> Trie.remove(k)
+    |> Trie.remove_key(k)
   end
 
   @spec fetch(DB.db(), EVM.trie_root(), integer()) :: integer() | nil
@@ -37,7 +37,7 @@ defmodule Blockchain.Account.Storage do
     result =
       db
       |> Trie.new(root)
-      |> Trie.get(k)
+      |> Trie.get_key(k)
 
     if is_nil(result), do: nil, else: ExRLP.decode(result)
   end

--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -293,7 +293,7 @@ defmodule Blockchain.Block do
     serialized_receipt =
       db
       |> Trie.new(block.header.receipts_root)
-      |> Trie.get(i |> ExRLP.encode())
+      |> Trie.get_key(i |> ExRLP.encode())
 
     case serialized_receipt do
       nil ->
@@ -337,7 +337,7 @@ defmodule Blockchain.Block do
     serialized_transaction =
       db
       |> Trie.new(block.header.transactions_root)
-      |> Trie.get(i |> ExRLP.encode())
+      |> Trie.get_key(i |> ExRLP.encode())
 
     case serialized_transaction do
       nil -> nil
@@ -803,7 +803,7 @@ defmodule Blockchain.Block do
     updated_receipts_root =
       db
       |> Trie.new(block.header.receipts_root)
-      |> Trie.update(ExRLP.encode(i), encoded_receipt)
+      |> Trie.update_key(ExRLP.encode(i), encoded_receipt)
 
     updated_header = %{block.header | receipts_root: updated_receipts_root.root_hash}
     updated_receipts = block.receipts ++ [receipt]
@@ -834,7 +834,7 @@ defmodule Blockchain.Block do
     updated_transactions_root =
       db
       |> Trie.new(block.header.transactions_root)
-      |> Trie.update(ExRLP.encode(i), encoded_transaction)
+      |> Trie.update_key(ExRLP.encode(i), encoded_transaction)
 
     %{
       block

--- a/apps/evm/lib/evm/account_repo.ex
+++ b/apps/evm/lib/evm/account_repo.ex
@@ -2,7 +2,7 @@ defmodule EVM.AccountRepo do
   alias Block.Header
 
   @moduledoc """
-  Module the defines a set of functions to interact with accounts.
+  Module that defines a set of functions to interact with accounts.
   """
 
   @type t :: struct()

--- a/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
@@ -417,7 +417,7 @@ defmodule ExWire.Struct.BlockQueue do
 
     trie =
       Enum.reduce(transactions_list |> Enum.with_index(), Trie.new(db), fn {trx, i}, trie ->
-        Trie.update(trie, ExRLP.encode(i), ExRLP.encode(trx))
+        Trie.update_key(trie, ExRLP.encode(i), ExRLP.encode(trx))
       end)
 
     trie.root_hash

--- a/apps/merkle_patricia_tree/README.md
+++ b/apps/merkle_patricia_tree/README.md
@@ -20,18 +20,18 @@ create an update a trie.
     iex> trie =
     ...>    MerklePatriciaTree.Test.random_ets_db()
     ...>    |> MerklePatriciaTree.Trie.new()
-    ...>    |> MerklePatriciaTree.Trie.update(<<0x01::4, 0x02::4>>, "wee")
-    ...>    |> MerklePatriciaTree.Trie.update(<<0x01::4, 0x02::4, 0x03::4>>, "cool")
-    iex> trie_2 = MerklePatriciaTree.Trie.update(trie, <<0x01::4, 0x02::4, 0x03::4>>, "cooler")
-    iex> MerklePatriciaTree.Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4>>)
+    ...>    |> MerklePatriciaTree.Trie.update_key(<<0x01::4, 0x02::4>>, "wee")
+    ...>    |> MerklePatriciaTree.Trie.update_key(<<0x01::4, 0x02::4, 0x03::4>>, "cool")
+    iex> trie_2 = MerklePatriciaTree.Trie.update_key(trie, <<0x01::4, 0x02::4, 0x03::4>>, "cooler")
+    iex> MerklePatriciaTree.Trie.get_key(trie_2, <<0x01::4, 0x02::4, 0x03::4>>)
     "cooler"
-    iex> MerklePatriciaTree.Trie.get(trie_2, <<0x01::4>>)
+    iex> MerklePatriciaTree.Trie.get_key(trie_2, <<0x01::4>>)
     nil
-    iex> MerklePatriciaTree.Trie.get(trie_2, <<0x01::4, 0x02::4>>)
+    iex> MerklePatriciaTree.Trie.get_key(trie_2, <<0x01::4, 0x02::4>>)
     "wee"
-    iex> MerklePatriciaTree.Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4>>)
+    iex> MerklePatriciaTree.Trie.get_key(trie_2, <<0x01::4, 0x02::4, 0x03::4>>)
     "cooler"
-    iex> MerklePatriciaTree.Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>)
+    iex> MerklePatriciaTree.Trie.get_key(trie_2, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>)
     nil
 ```
 

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
@@ -8,7 +8,7 @@ defmodule MerklePatriciaTree.CachingTrie do
   alias MerklePatriciaTree.Trie.Node
   alias MerklePatriciaTree.Trie.Storage
 
-  @behaviour MerklePatriciaTree.StorageBehaviour
+  @behaviour MerklePatriciaTree.Storage
 
   defstruct [
     :in_memory_trie,
@@ -91,8 +91,7 @@ defmodule MerklePatriciaTree.CachingTrie do
     rlp = Helper.rlp_encode(in_memory_trie.root_hash)
 
     # Let's check if it is RLP or Keccak-256 hash.
-    # Keccak-256 is always 32-bytes.
-    if byte_size(rlp) < Storage.max_rlp_len() do
+    if Storage.keccak_hash?(rlp) do
       # It is RLP, so we need to calc KEC-256 and
       # store it in the database.
       kec = Storage.store(rlp, in_memory_trie.db)

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
@@ -1,0 +1,114 @@
+defmodule MerklePatriciaTree.CachingTrie do
+  alias MerklePatriciaTree.Trie
+
+  alias MerklePatriciaTree.Trie.Builder
+  alias MerklePatriciaTree.Trie.Destroyer
+  alias MerklePatriciaTree.Trie.Fetcher
+  alias MerklePatriciaTree.Trie.Helper
+  alias MerklePatriciaTree.Trie.Node
+  alias MerklePatriciaTree.Trie.Storage
+
+  @behaviour MerklePatriciaTree.StorageBehaviour
+
+  defstruct [
+    :in_memory_trie,
+    :trie
+  ]
+
+  @type t :: %__MODULE__{
+          in_memory_trie: Trie.t(),
+          trie: Trie.t()
+        }
+
+  def new(trie) do
+    ets_db = MerklePatriciaTree.Test.random_ets_db()
+    in_memory_trie = Trie.new(ets_db, trie.root_hash)
+
+    %__MODULE__{
+      in_memory_trie: in_memory_trie,
+      trie: trie
+    }
+  end
+
+  @impl true
+  def fetch_node(caching_trie) do
+    in_memory_node = Node.decode_trie(caching_trie.in_memory_trie)
+
+    if in_memory_node == :empty do
+      trie = %{caching_trie.trie | root_hash: caching_trie.in_memory_trie.root_hash}
+
+      Node.decode_trie(trie)
+    else
+      in_memory_node
+    end
+  end
+
+  @impl true
+  def put_node(node, caching_trie) do
+    Node.encode_node(node, caching_trie.in_memory_trie)
+  end
+
+  @impl true
+  def remove_key(caching_trie, key) do
+    key_nibbles = Helper.get_nibbles(key)
+
+    caching_trie
+    |> fetch_node()
+    |> Destroyer.remove_key(key_nibbles, caching_trie)
+    |> put_node(caching_trie)
+    |> into(caching_trie)
+    |> store()
+  end
+
+  @impl true
+  def update_key(caching_trie, key, value) do
+    if is_nil(value) do
+      remove_key(caching_trie, key)
+    else
+      key_nibbles = Helper.get_nibbles(key)
+      # We're going to recursively walk toward our key,
+      # then we'll add our value (either a new leaf or the value
+      # on a branch node), then we'll walk back up the tree and
+      # update all previous nodes.
+      # This may require changing the type of the node.
+      caching_trie
+      |> fetch_node()
+      |> Builder.put_key(key_nibbles, value, caching_trie)
+      |> put_node(caching_trie)
+      |> into(caching_trie)
+      |> store()
+    end
+  end
+
+  @impl true
+  def get_key(caching_trie, key) do
+    Fetcher.get(caching_trie, key)
+  end
+
+  @impl true
+  def store(caching_trie) do
+    in_memory_trie = caching_trie.in_memory_trie
+    rlp = Helper.rlp_encode(in_memory_trie.root_hash)
+
+    # Let's check if it is RLP or Keccak-256 hash.
+    # Keccak-256 is always 32-bytes.
+    if byte_size(rlp) < Storage.max_rlp_len() do
+      # It is RLP, so we need to calc KEC-256 and
+      # store it in the database.
+      kec = Storage.store(rlp, in_memory_trie.db)
+      updated_in_memory_trie = %{in_memory_trie | root_hash: kec}
+      %{caching_trie | in_memory_trie: updated_in_memory_trie}
+    else
+      # It is SHA3/Keccak-256,
+      # so we know it is already stored in the DB.
+      caching_trie
+    end
+  end
+
+  @impl true
+  def into(next_node, caching_trie) do
+    updated_in_memory_trie = %{caching_trie.in_memory_trie | root_hash: next_node}
+
+    %{caching_trie | in_memory_trie: updated_in_memory_trie}
+  end
+end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/storage.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/storage.ex
@@ -1,4 +1,4 @@
-defmodule MerklePatriciaTree.StorageBehaviour do
+defmodule MerklePatriciaTree.Storage do
   @moduledoc """
   Defines functions for fetching and updating nodes.
   """

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/storage_behaviour.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/storage_behaviour.ex
@@ -1,0 +1,28 @@
+defmodule MerklePatriciaTree.StorageBehaviour do
+  @moduledoc """
+  Defines functions for fetching and updating nodes.
+  """
+
+  alias MerklePatriciaTree.Trie
+  alias MerklePatriciaTree.Trie.Node
+
+  @type t :: struct()
+
+  @callback fetch_node(t) :: Node.trie_node()
+
+  @callback put_node(node, t) :: nil | binary()
+
+  @callback remove_key(t, Trie.key()) :: t
+
+  @callback update_key(t(), Trie.key(), ExRLP.t() | nil) :: t
+
+  @callback get_key(t(), Trie.key()) :: t()
+
+  @callback into(binary(), t) :: t
+
+  @callback store(t) :: t
+
+  def storage(implementation) do
+    implementation.__struct__
+  end
+end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/storage_behaviour.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/storage_behaviour.ex
@@ -12,11 +12,11 @@ defmodule MerklePatriciaTree.StorageBehaviour do
 
   @callback put_node(node, t) :: nil | binary()
 
-  @callback remove_key(t, Trie.key()) :: t
+  @callback remove_key(t, Trie.key()) :: Node.trie_node()
 
   @callback update_key(t(), Trie.key(), ExRLP.t() | nil) :: t
 
-  @callback get_key(t(), Trie.key()) :: t()
+  @callback get_key(t(), Trie.key()) :: nil | binary()
 
   @callback into(binary(), t) :: t
 

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
@@ -2,10 +2,12 @@ defmodule MerklePatriciaTree.Trie do
   @moduledoc File.read!("#{__DIR__}/../../README.md")
 
   alias ExthCrypto.Hash.Keccak
-  alias MerklePatriciaTree.Trie.{Builder, Destroyer, Helper, Node, Storage}
-  alias MerklePatriciaTree.{DB, ListHelper}
+  alias MerklePatriciaTree.DB
+  alias MerklePatriciaTree.Trie.{Builder, Destroyer, Fetcher, Helper, Node, Storage}
 
   defstruct db: nil, root_hash: nil
+
+  @behaviour MerklePatriciaTree.StorageBehaviour
 
   @type root_hash :: binary()
 
@@ -62,6 +64,16 @@ defmodule MerklePatriciaTree.Trie do
     %__MODULE__{db: db, root_hash: root_hash} |> store()
   end
 
+  @impl true
+  def fetch_node(trie) do
+    Node.decode_trie(trie)
+  end
+
+  @impl true
+  def put_node(node, trie) do
+    Node.encode_node(node, trie)
+  end
+
   @doc """
   Moves trie down to be rooted at `next_node`,
   this is effectively (and literally) just changing
@@ -69,6 +81,7 @@ defmodule MerklePatriciaTree.Trie do
   Used for trie traversal (ext and branch nodes) and
   for creating new tries with the same underlying db.
   """
+  @impl true
   def into(next_node, trie) do
     %{trie | root_hash: next_node}
   end
@@ -76,110 +89,54 @@ defmodule MerklePatriciaTree.Trie do
   @doc """
   Given a trie, returns the value associated with key.
   """
-  @spec get(t(), key()) :: binary() | nil
-  def get(trie, key) do
-    do_get(trie, Helper.get_nibbles(key))
-  end
-
-  @spec do_get(t() | nil, [integer()]) :: binary() | nil
-  defp do_get(nil, _), do: nil
-
-  defp do_get(trie, nibbles = [nibble | rest]) do
-    # Let's decode `c(I, i)`
-
-    case Node.decode_trie(trie) do
-      # No node, bail
-      :empty ->
-        nil
-
-      # Leaf node
-      {:leaf, prefix, value} ->
-        if prefix == nibbles,
-          do: value,
-          else: nil
-
-      # Extension, continue walking trie if we match
-      {:ext, shared_prefix, next_node} ->
-        case ListHelper.get_postfix(nibbles, shared_prefix) do
-          # Did not match extension node
-          nil ->
-            nil
-
-          rest ->
-            next_node |> into(trie) |> do_get(rest)
-        end
-
-      # Branch node
-      {:branch, branches} ->
-        case Enum.at(branches, nibble) do
-          [] -> nil
-          node_hash -> node_hash |> into(trie) |> do_get(rest)
-        end
-    end
-  end
-
-  defp do_get(trie, []) do
-    # No prefix left, its either branch or leaf node
-    case Node.decode_trie(trie) do
-      # In branch node value is always the last element
-      {:branch, branches} ->
-        value = List.last(branches)
-        # Decode empty value as nil, see Eq.(194)
-        if value == <<>>, do: nil, else: value
-
-      {:leaf, [], v} ->
-        v
-
-      _ ->
-        nil
-    end
+  @impl true
+  def get_key(trie, key) do
+    Fetcher.get(trie, key)
   end
 
   @doc """
   Updates a trie by setting key equal to value.
   If value is nil, we will instead remove `key` from the trie.
   """
-  @spec update(t(), key(), ExRLP.t() | nil) :: t()
-  def update(trie, key, nil), do: remove(trie, key)
 
-  def update(trie, key, value) do
-    key_nibbles = Helper.get_nibbles(key)
-    # We're going to recursively walk toward our key,
-    # then we'll add our value (either a new leaf or the value
-    # on a branch node), then we'll walk back up the tree and
-    # update all previous nodes.
-    # This may require changing the type of the node.
-    trie
-    |> Node.decode_trie()
-    |> Builder.put_key(key_nibbles, value, trie)
-    |> Node.encode_node(trie)
-    |> into(trie)
-    |> store()
+  @impl true
+  def update_key(trie, key, value) do
+    if is_nil(value) do
+      remove_key(trie, key)
+    else
+      key_nibbles = Helper.get_nibbles(key)
+      # We're going to recursively walk toward our key,
+      # then we'll add our value (either a new leaf or the value
+      # on a branch node), then we'll walk back up the tree and
+      # update all previous nodes.
+      # This may require changing the type of the node.
+      trie
+      |> fetch_node()
+      |> Builder.put_key(key_nibbles, value, trie)
+      |> put_node(trie)
+      |> into(trie)
+      |> store()
+    end
   end
 
   @doc """
   Removes `key` from the `trie`.
   """
-  @spec remove(t(), key()) :: t()
-  def remove(trie, key) do
+  @impl true
+  def remove_key(trie, key) do
     key_nibbles = Helper.get_nibbles(key)
 
-    new_trie =
-      trie
-      |> Node.decode_trie()
-      |> Destroyer.remove_key(key_nibbles, trie)
-      |> Node.encode_node(trie)
-      |> into(trie)
-      |> store()
-
-    # TODO: https://github.com/poanetwork/mana/issues/229
-    # Storage.delete(trie)
-
-    new_trie
+    trie
+    |> fetch_node()
+    |> Destroyer.remove_key(key_nibbles, trie)
+    |> put_node(trie)
+    |> into(trie)
+    |> store()
   end
 
+  @impl true
   def store(trie) do
-    rlp = rlp_encode(trie.root_hash)
+    rlp = Helper.rlp_encode(trie.root_hash)
 
     # Let's check if it is RLP or Keccak-256 hash.
     # Keccak-256 is always 32-bytes.
@@ -194,9 +151,4 @@ defmodule MerklePatriciaTree.Trie do
       trie
     end
   end
-
-  # Encodes `x` in RLP if it isn't already encoded.
-  # And it is definitely not encoded if it is `<<>>` or not a binary (e.g. array).
-  defp rlp_encode(x) when not is_binary(x) or x == <<>>, do: ExRLP.encode(x)
-  defp rlp_encode(x), do: x
 end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
@@ -7,7 +7,7 @@ defmodule MerklePatriciaTree.Trie do
 
   defstruct db: nil, root_hash: nil
 
-  @behaviour MerklePatriciaTree.StorageBehaviour
+  @behaviour MerklePatriciaTree.Storage
 
   @type root_hash :: binary()
 
@@ -139,8 +139,7 @@ defmodule MerklePatriciaTree.Trie do
     rlp = Helper.rlp_encode(trie.root_hash)
 
     # Let's check if it is RLP or Keccak-256 hash.
-    # Keccak-256 is always 32-bytes.
-    if byte_size(rlp) < Storage.max_rlp_len() do
+    if Storage.keccak_hash?(rlp) do
       # It is RLP, so we need to calc KEC-256 and
       # store it in the database.
       kec = Storage.store(rlp, trie.db)

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/builder.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/builder.ex
@@ -13,6 +13,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
 
   import MerklePatriciaTree.ListHelper, only: [overlap: 2]
 
+  alias MerklePatriciaTree.StorageBehaviour
   alias MerklePatriciaTree.Trie
   alias MerklePatriciaTree.Trie.Node
 
@@ -48,7 +49,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
     branch =
       [{old_tl, old_value}, {new_tl, new_value}]
       |> build_branch(trie)
-      |> Node.encode_node(trie)
+      |> StorageBehaviour.storage(trie).put_node(trie)
 
     {:ext, matching_prefix, branch}
   end
@@ -69,13 +70,13 @@ defmodule MerklePatriciaTree.Trie.Builder do
      List.update_at(nodes, prefix_hd, fn branch ->
        node =
          branch
-         |> Trie.into(trie)
-         |> Node.decode_trie()
+         |> StorageBehaviour.storage(trie).into(trie)
+         |> StorageBehaviour.storage(trie).fetch_node()
 
        # Insert the rest
        node
        |> put_key(prefix_tl, value, trie)
-       |> Node.encode_node(trie)
+       |> StorageBehaviour.storage(trie).put_node(trie)
      end)}
   end
 
@@ -111,15 +112,15 @@ defmodule MerklePatriciaTree.Trie.Builder do
       # This is our decoded old branch trie.
       old_trie =
         old_value
-        |> Trie.into(trie)
-        |> Node.decode_trie()
+        |> StorageBehaviour.storage(trie).into(trie)
+        |> StorageBehaviour.storage(trie).fetch_node()
 
       # Recursively merge the new value into
       # the old branch trie.
       new_encoded_trie =
         old_trie
         |> put_key(new_tl, new_value, trie)
-        |> Node.encode_node(trie)
+        |> StorageBehaviour.storage(trie).put_node(trie)
 
       {:ext, matching_prefix, new_encoded_trie}
     else
@@ -150,14 +151,14 @@ defmodule MerklePatriciaTree.Trie.Builder do
           # They have some common/shared prefix nibbles.
           # So we need to "insert" an extension node.
           [h | t] ->
-            ext_encoded = Node.encode_node({:ext, t, old_value}, trie)
+            ext_encoded = StorageBehaviour.storage(trie).put_node({:ext, t, old_value}, trie)
             {h, {:encoded, ext_encoded}}
         end
 
       branch =
         [first, {new_tl, new_value}]
         |> build_branch(trie)
-        |> Node.encode_node(trie)
+        |> StorageBehaviour.storage(trie).put_node(trie)
 
       {:ext, matching_prefix, branch}
     end
@@ -171,7 +172,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
           {h, {:encoded, old_value}}
 
         [h | t] ->
-          ext_encoded = Node.encode_node({:ext, t, old_value}, trie)
+          ext_encoded = StorageBehaviour.storage(trie).put_node({:ext, t, old_value}, trie)
           {h, {:encoded, ext_encoded}}
       end
 

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/builder.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/builder.ex
@@ -13,7 +13,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
 
   import MerklePatriciaTree.ListHelper, only: [overlap: 2]
 
-  alias MerklePatriciaTree.StorageBehaviour
+  alias MerklePatriciaTree.Storage
   alias MerklePatriciaTree.Trie
   alias MerklePatriciaTree.Trie.Node
 
@@ -24,7 +24,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
 
   This may radically change the structure of the trie.
   """
-  @spec put_key(Node.trie_node(), Trie.key(), ExRLP.t(), StorageBehaviour.t()) :: Node.trie_node()
+  @spec put_key(Node.trie_node(), Trie.key(), ExRLP.t(), Storage.t()) :: Node.trie_node()
   def put_key(trie_node, key, value, trie) do
     trie_put_key(trie_node, key, value, trie)
   end
@@ -49,7 +49,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
     branch =
       [{old_tl, old_value}, {new_tl, new_value}]
       |> build_branch(trie)
-      |> StorageBehaviour.storage(trie).put_node(trie)
+      |> Storage.storage(trie).put_node(trie)
 
     {:ext, matching_prefix, branch}
   end
@@ -70,13 +70,13 @@ defmodule MerklePatriciaTree.Trie.Builder do
      List.update_at(nodes, prefix_hd, fn branch ->
        node =
          branch
-         |> StorageBehaviour.storage(trie).into(trie)
-         |> StorageBehaviour.storage(trie).fetch_node()
+         |> Storage.storage(trie).into(trie)
+         |> Storage.storage(trie).fetch_node()
 
        # Insert the rest
        node
        |> put_key(prefix_tl, value, trie)
-       |> StorageBehaviour.storage(trie).put_node(trie)
+       |> Storage.storage(trie).put_node(trie)
      end)}
   end
 
@@ -112,15 +112,15 @@ defmodule MerklePatriciaTree.Trie.Builder do
       # This is our decoded old branch trie.
       old_trie =
         old_value
-        |> StorageBehaviour.storage(trie).into(trie)
-        |> StorageBehaviour.storage(trie).fetch_node()
+        |> Storage.storage(trie).into(trie)
+        |> Storage.storage(trie).fetch_node()
 
       # Recursively merge the new value into
       # the old branch trie.
       new_encoded_trie =
         old_trie
         |> put_key(new_tl, new_value, trie)
-        |> StorageBehaviour.storage(trie).put_node(trie)
+        |> Storage.storage(trie).put_node(trie)
 
       {:ext, matching_prefix, new_encoded_trie}
     else
@@ -151,14 +151,14 @@ defmodule MerklePatriciaTree.Trie.Builder do
           # They have some common/shared prefix nibbles.
           # So we need to "insert" an extension node.
           [h | t] ->
-            ext_encoded = StorageBehaviour.storage(trie).put_node({:ext, t, old_value}, trie)
+            ext_encoded = Storage.storage(trie).put_node({:ext, t, old_value}, trie)
             {h, {:encoded, ext_encoded}}
         end
 
       branch =
         [first, {new_tl, new_value}]
         |> build_branch(trie)
-        |> StorageBehaviour.storage(trie).put_node(trie)
+        |> Storage.storage(trie).put_node(trie)
 
       {:ext, matching_prefix, branch}
     end
@@ -172,7 +172,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
           {h, {:encoded, old_value}}
 
         [h | t] ->
-          ext_encoded = StorageBehaviour.storage(trie).put_node({:ext, t, old_value}, trie)
+          ext_encoded = Storage.storage(trie).put_node({:ext, t, old_value}, trie)
           {h, {:encoded, ext_encoded}}
       end
 

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/builder.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/builder.ex
@@ -24,7 +24,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
 
   This may radically change the structure of the trie.
   """
-  @spec put_key(Node.trie_node(), Trie.key(), ExRLP.t(), Trie.t()) :: Node.trie_node()
+  @spec put_key(Node.trie_node(), Trie.key(), ExRLP.t(), StorageBehaviour.t()) :: Node.trie_node()
   def put_key(trie_node, key, value, trie) do
     trie_put_key(trie_node, key, value, trie)
   end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/destroyer.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/destroyer.ex
@@ -13,7 +13,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
 
   import MerklePatriciaTree.ListHelper, only: [overlap: 2]
 
-  alias MerklePatriciaTree.StorageBehaviour
+  alias MerklePatriciaTree.Storage
   alias MerklePatriciaTree.Trie
   alias MerklePatriciaTree.Trie.Node
 
@@ -24,7 +24,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
 
   This may radically change the structure of the trie.
   """
-  @spec remove_key(Node.trie_node(), Trie.key(), StorageBehaviour.t()) :: Node.trie_node()
+  @spec remove_key(Node.trie_node(), Trie.key(), Storage.t()) :: Node.trie_node()
   def remove_key(trie_node, key, trie) do
     trie_remove_key(trie_node, key, trie)
   end
@@ -47,8 +47,8 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
     if Enum.empty?(ext_tl) do
       existing_node =
         node_hash
-        |> StorageBehaviour.storage(trie).into(trie)
-        |> StorageBehaviour.storage(trie).fetch_node()
+        |> Storage.storage(trie).into(trie)
+        |> Storage.storage(trie).fetch_node()
 
       updated_node = trie_remove_key(existing_node, remaining_tl, trie)
 
@@ -66,7 +66,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
           {:ext, ext_prefix ++ new_ext_prefix, new_ext_node_hash}
 
         elements ->
-          encoded = StorageBehaviour.storage(trie).put_node(elements, trie)
+          encoded = Storage.storage(trie).put_node(elements, trie)
           {:ext, ext_prefix, encoded}
       end
     else
@@ -89,12 +89,12 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
       List.update_at(branches, prefix_hd, fn branch ->
         branch_node =
           branch
-          |> StorageBehaviour.storage(trie).into(trie)
-          |> StorageBehaviour.storage(trie).fetch_node()
+          |> Storage.storage(trie).into(trie)
+          |> Storage.storage(trie).fetch_node()
 
         branch_node
         |> trie_remove_key(prefix_tl, trie)
-        |> StorageBehaviour.storage(trie).put_node(trie)
+        |> Storage.storage(trie).put_node(trie)
       end)
 
     non_blank_branches =
@@ -116,8 +116,8 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
 
         decoded_branch_node =
           branch_node
-          |> StorageBehaviour.storage(trie).into(trie)
-          |> StorageBehaviour.storage(trie).fetch_node()
+          |> Storage.storage(trie).into(trie)
+          |> Storage.storage(trie).fetch_node()
 
         case decoded_branch_node do
           {:leaf, leaf_prefix, leaf_value} ->

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/destroyer.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/destroyer.ex
@@ -13,6 +13,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
 
   import MerklePatriciaTree.ListHelper, only: [overlap: 2]
 
+  alias MerklePatriciaTree.StorageBehaviour
   alias MerklePatriciaTree.Trie
   alias MerklePatriciaTree.Trie.Node
 
@@ -46,8 +47,8 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
     if Enum.empty?(ext_tl) do
       existing_node =
         node_hash
-        |> Trie.into(trie)
-        |> Node.decode_trie()
+        |> StorageBehaviour.storage(trie).into(trie)
+        |> StorageBehaviour.storage(trie).fetch_node()
 
       updated_node = trie_remove_key(existing_node, remaining_tl, trie)
 
@@ -65,7 +66,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
           {:ext, ext_prefix ++ new_ext_prefix, new_ext_node_hash}
 
         elements ->
-          encoded = Node.encode_node(elements, trie)
+          encoded = StorageBehaviour.storage(trie).put_node(elements, trie)
           {:ext, ext_prefix, encoded}
       end
     else
@@ -88,12 +89,12 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
       List.update_at(branches, prefix_hd, fn branch ->
         branch_node =
           branch
-          |> Trie.into(trie)
-          |> Node.decode_trie()
+          |> StorageBehaviour.storage(trie).into(trie)
+          |> StorageBehaviour.storage(trie).fetch_node()
 
         branch_node
         |> trie_remove_key(prefix_tl, trie)
-        |> Node.encode_node(trie)
+        |> StorageBehaviour.storage(trie).put_node(trie)
       end)
 
     non_blank_branches =
@@ -113,7 +114,10 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
         # We just have a node we need to percolate up.
         {branch_node, i} = List.first(non_blank_branches)
 
-        decoded_branch_node = Node.decode_trie(branch_node |> Trie.into(trie))
+        decoded_branch_node =
+          branch_node
+          |> StorageBehaviour.storage(trie).into(trie)
+          |> StorageBehaviour.storage(trie).fetch_node()
 
         case decoded_branch_node do
           {:leaf, leaf_prefix, leaf_value} ->

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/destroyer.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/destroyer.ex
@@ -24,7 +24,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
 
   This may radically change the structure of the trie.
   """
-  @spec remove_key(Node.trie_node(), Trie.key(), Trie.t()) :: Node.trie_node()
+  @spec remove_key(Node.trie_node(), Trie.key(), StorageBehaviour.t()) :: Node.trie_node()
   def remove_key(trie_node, key, trie) do
     trie_remove_key(trie_node, key, trie)
   end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/fetcher.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/fetcher.ex
@@ -1,0 +1,63 @@
+defmodule MerklePatriciaTree.Trie.Fetcher do
+  alias MerklePatriciaTree.ListHelper
+  alias MerklePatriciaTree.StorageBehaviour
+  alias MerklePatriciaTree.Trie.Helper
+
+  def get(trie, key) do
+    do_get(trie, Helper.get_nibbles(key))
+  end
+
+  @spec do_get(StorageBehaviour.t() | nil, [integer()]) :: binary() | nil
+  defp do_get(nil, _), do: nil
+
+  defp do_get(trie, nibbles = [nibble | rest]) do
+    # Let's decode `c(I, i)`
+
+    case StorageBehaviour.storage(trie).fetch_node(trie) do
+      # No node, bail
+      :empty ->
+        nil
+
+      # Leaf node
+      {:leaf, prefix, value} ->
+        if prefix == nibbles,
+          do: value,
+          else: nil
+
+      # Extension, continue walking trie if we match
+      {:ext, shared_prefix, next_node} ->
+        case ListHelper.get_postfix(nibbles, shared_prefix) do
+          # Did not match extension node
+          nil ->
+            nil
+
+          rest ->
+            next_node |> StorageBehaviour.storage(trie).into(trie) |> do_get(rest)
+        end
+
+      # Branch node
+      {:branch, branches} ->
+        case Enum.at(branches, nibble) do
+          [] -> nil
+          node_hash -> node_hash |> StorageBehaviour.storage(trie).into(trie) |> do_get(rest)
+        end
+    end
+  end
+
+  defp do_get(trie, []) do
+    # No prefix left, its either branch or leaf node
+    case StorageBehaviour.storage(trie).fetch_node(trie) do
+      # In branch node value is always the last element
+      {:branch, branches} ->
+        value = List.last(branches)
+        # Decode empty value as nil, see Eq.(194)
+        if value == <<>>, do: nil, else: value
+
+      {:leaf, [], v} ->
+        v
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/fetcher.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/fetcher.ex
@@ -1,19 +1,19 @@
 defmodule MerklePatriciaTree.Trie.Fetcher do
   alias MerklePatriciaTree.ListHelper
-  alias MerklePatriciaTree.StorageBehaviour
+  alias MerklePatriciaTree.Storage
   alias MerklePatriciaTree.Trie.Helper
 
   def get(trie, key) do
     do_get(trie, Helper.get_nibbles(key))
   end
 
-  @spec do_get(StorageBehaviour.t() | nil, [integer()]) :: binary() | nil
+  @spec do_get(Storage.t() | nil, [integer()]) :: binary() | nil
   defp do_get(nil, _), do: nil
 
   defp do_get(trie, nibbles = [nibble | rest]) do
     # Let's decode `c(I, i)`
 
-    case StorageBehaviour.storage(trie).fetch_node(trie) do
+    case Storage.storage(trie).fetch_node(trie) do
       # No node, bail
       :empty ->
         nil
@@ -32,21 +32,21 @@ defmodule MerklePatriciaTree.Trie.Fetcher do
             nil
 
           rest ->
-            next_node |> StorageBehaviour.storage(trie).into(trie) |> do_get(rest)
+            next_node |> Storage.storage(trie).into(trie) |> do_get(rest)
         end
 
       # Branch node
       {:branch, branches} ->
         case Enum.at(branches, nibble) do
           [] -> nil
-          node_hash -> node_hash |> StorageBehaviour.storage(trie).into(trie) |> do_get(rest)
+          node_hash -> node_hash |> Storage.storage(trie).into(trie) |> do_get(rest)
         end
     end
   end
 
   defp do_get(trie, []) do
     # No prefix left, its either branch or leaf node
-    case StorageBehaviour.storage(trie).fetch_node(trie) do
+    case Storage.storage(trie).fetch_node(trie) do
       # In branch node value is always the last element
       {:branch, branches} ->
         value = List.last(branches)

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/helper.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/helper.ex
@@ -40,4 +40,9 @@ defmodule MerklePatriciaTree.Trie.Helper do
   def get_binary(l) do
     for x <- l, into: <<>>, do: <<x::4>>
   end
+
+  # Encodes `x` in RLP if it isn't already encoded.
+  # And it is definitely not encoded if it is `<<>>` or not a binary (e.g. array).
+  def rlp_encode(x) when not is_binary(x) or x == <<>>, do: ExRLP.encode(x)
+  def rlp_encode(x), do: x
 end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/inspector.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/inspector.ex
@@ -13,11 +13,11 @@ defmodule MerklePatriciaTree.Trie.Inspector do
   ## Examples
 
       iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
-      ...>   |> MerklePatriciaTree.Trie.update("type", "fighter")
-      ...>   |> MerklePatriciaTree.Trie.update("name", "bob")
-      ...>   |> MerklePatriciaTree.Trie.update("nationality", "usa")
-      ...>   |> MerklePatriciaTree.Trie.update("nato", "strong")
-      ...>   |> MerklePatriciaTree.Trie.update((for x <- 1..100, into: <<>>, do: <<x::8>>), (for x <- 1..100, into: <<>>, do: <<x*2::8>>))
+      ...>   |> MerklePatriciaTree.Trie.update_key("type", "fighter")
+      ...>   |> MerklePatriciaTree.Trie.update_key("name", "bob")
+      ...>   |> MerklePatriciaTree.Trie.update_key("nationality", "usa")
+      ...>   |> MerklePatriciaTree.Trie.update_key("nato", "strong")
+      ...>   |> MerklePatriciaTree.Trie.update_key((for x <- 1..100, into: <<>>, do: <<x::8>>), (for x <- 1..100, into: <<>>, do: <<x*2::8>>))
       ...>   |> MerklePatriciaTree.Trie.Inspector.all_values()
       [
         {(for x <- 1..100, into: <<>>, do: <<x::8>>), (for x <- 1..100, into: <<>>, do: <<x*2::8>>)},
@@ -72,11 +72,11 @@ defmodule MerklePatriciaTree.Trie.Inspector do
   ## Examples
 
       iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
-      ...>   |> MerklePatriciaTree.Trie.update("type", "fighter")
-      ...>   |> MerklePatriciaTree.Trie.update("name", "bob")
-      ...>   |> MerklePatriciaTree.Trie.update("nationality", "usa")
-      ...>   |> MerklePatriciaTree.Trie.update("nato", "strong")
-      ...>   |> MerklePatriciaTree.Trie.update((for x <- 1..100, into: <<>>, do: <<x::8>>), (for x <- 1..100, into: <<>>, do: <<x*2::8>>))
+      ...>   |> MerklePatriciaTree.Trie.update_key("type", "fighter")
+      ...>   |> MerklePatriciaTree.Trie.update_key("name", "bob")
+      ...>   |> MerklePatriciaTree.Trie.update_key("nationality", "usa")
+      ...>   |> MerklePatriciaTree.Trie.update_key("nato", "strong")
+      ...>   |> MerklePatriciaTree.Trie.update_key((for x <- 1..100, into: <<>>, do: <<x::8>>), (for x <- 1..100, into: <<>>, do: <<x*2::8>>))
       ...>   |> MerklePatriciaTree.Trie.Inspector.all_keys()
       [
         (for x <- 1..100, into: <<>>, do: <<x::8>>),

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/storage.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/storage.ex
@@ -14,6 +14,9 @@ defmodule MerklePatriciaTree.Trie.Storage do
   @spec max_rlp_len() :: integer()
   def max_rlp_len(), do: @max_rlp_len
 
+  # Keccak-256 is always 32-bytes.
+  def keccak_hash?(bytes), do: byte_size(bytes) < max_rlp_len()
+
   @doc """
   Takes an RLP-encoded node and pushes it to storage,
   as defined by `n(I, i)` Eq.(178) of the Yellow Paper.

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
@@ -1,0 +1,110 @@
+defmodule MerklePatriciaTree.CachingTrieTest do
+  use ExUnit.Case, async: true
+
+  alias MerklePatriciaTree.CachingTrie
+  alias MerklePatriciaTree.Trie
+
+  setup do
+    disk_trie =
+      "/tmp/#{MerklePatriciaTree.Test.random_string(20)}"
+      |> MerklePatriciaTree.DB.RocksDB.init()
+      |> MerklePatriciaTree.Trie.new()
+
+    {:ok, %{disk_trie: disk_trie}}
+  end
+
+  describe "new/1" do
+    test "initializes new CachingTrie", %{disk_trie: disk_trie} do
+      caching_trie = CachingTrie.new(disk_trie)
+
+      assert caching_trie.in_memory_trie.root_hash == disk_trie.root_hash
+    end
+  end
+
+  describe "get_key/2" do
+    test "fetches data from disk trie when in-memory try is empty", %{disk_trie: disk_trie} do
+      disk_trie = Trie.update_key(disk_trie, "foo", "bar")
+
+      caching_trie = CachingTrie.new(disk_trie)
+
+      result = CachingTrie.get_key(caching_trie, "foo")
+      assert result == "bar"
+    end
+
+    test "fetched one value from disk trie, another from in-memory try", %{disk_trie: disk_trie} do
+      disk_trie = Trie.update_key(disk_trie, "foo", "bar")
+
+      caching_trie =
+        disk_trie
+        |> CachingTrie.new()
+        |> CachingTrie.update_key("foo1", "bar1")
+
+      result = CachingTrie.get_key(caching_trie, "foo")
+      assert result == "bar"
+
+      result = Trie.get_key(caching_trie.trie, "foo")
+      assert result == "bar"
+
+      result = CachingTrie.get_key(caching_trie, "foo1")
+      assert result == "bar1"
+
+      result = Trie.get_key(caching_trie.in_memory_trie, "foo1")
+      assert result == "bar1"
+    end
+  end
+
+  describe "remove_key/2" do
+    test "removes key updating in-memory trie", %{disk_trie: disk_trie} do
+      caching_trie =
+        disk_trie
+        |> Trie.update_key("foo", "bar")
+        |> Trie.update_key("foo1", "bar1")
+        |> CachingTrie.new()
+
+      result = CachingTrie.get_key(caching_trie, "foo")
+      assert result == "bar"
+
+      updated_caching_trie = CachingTrie.remove_key(caching_trie, "foo")
+
+      result = CachingTrie.get_key(updated_caching_trie, "foo")
+      assert is_nil(result)
+
+      result = CachingTrie.get_key(caching_trie.trie, "foo")
+      assert result == "bar"
+    end
+  end
+
+  describe "update_key/3" do
+    test "updates key in in-memory trie", %{disk_trie: disk_trie} do
+      caching_trie = CachingTrie.new(disk_trie)
+
+      updated_caching_trie = CachingTrie.update_key(caching_trie, "foo", "bar")
+
+      result = CachingTrie.get_key(updated_caching_trie, "foo")
+      assert result == "bar"
+
+      result = Trie.get_key(updated_caching_trie.in_memory_trie, "foo")
+      assert result == "bar"
+    end
+
+    test "sets correct storage root to in-memory trie", %{disk_trie: disk_trie} do
+      disk_trie = Trie.update_key(disk_trie, "elixir", "erlang")
+
+      updated_disk_trie =
+        disk_trie
+        |> Trie.update_key("foo", "bar")
+        |> Trie.update_key("foo1", "bar1")
+        |> Trie.update_key("foo2", "bar2")
+
+      caching_trie =
+        disk_trie
+        |> CachingTrie.new()
+        |> CachingTrie.update_key("foo", "bar")
+        |> CachingTrie.update_key("foo1", "bar1")
+        |> CachingTrie.update_key("foo2", "bar2")
+
+      assert updated_disk_trie.root_hash == caching_trie.in_memory_trie.root_hash
+      assert caching_trie.trie.root_hash == disk_trie.root_hash
+    end
+  end
+end

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/trie_test.exs
@@ -17,7 +17,7 @@ defmodule MerklePatriciaTree.TrieTest do
     trie = Trie.new(MerklePatriciaTree.Test.random_ets_db())
 
     assert trie.root_hash == Trie.empty_trie_root_hash()
-    assert Trie.get(trie, <<0x01, 0x02, 0x03>>) == nil
+    assert Trie.get_key(trie, <<0x01, 0x02, 0x03>>) == nil
   end
 
   describe "get" do
@@ -25,10 +25,10 @@ defmodule MerklePatriciaTree.TrieTest do
       root_hash = leaf_node([0x01, 0x02, 0x03], "cool")
       trie = Trie.new(db, root_hash)
 
-      assert Trie.get(trie, <<0x01::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4>>) == "cool"
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4>>) == "cool"
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
     end
 
     test "with an extension node followed by a leaf", %{db: db} do
@@ -40,10 +40,10 @@ defmodule MerklePatriciaTree.TrieTest do
 
       trie = Trie.new(db, root_hash)
 
-      assert Trie.get(trie, <<0x01::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4>>) == "cool"
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4>>) == "cool"
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
     end
 
     test "with an extension node followed by an extension node and then leaf", %{db: db} do
@@ -63,11 +63,11 @@ defmodule MerklePatriciaTree.TrieTest do
 
       trie = Trie.new(db, root_hash)
 
-      assert Trie.get(trie, <<0x01::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == "cool"
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4, 0x05::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == "cool"
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4, 0x05::4>>) == nil
     end
 
     test "with a branch node", %{db: db} do
@@ -87,11 +87,11 @@ defmodule MerklePatriciaTree.TrieTest do
 
       trie = Trie.new(db, root_hash)
 
-      assert Trie.get(trie, <<0x01::4>>) == "cool"
-      assert Trie.get(trie, <<0x01::4, 0x00::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x00::4, 0x02::4>>) == "hi"
-      assert Trie.get(trie, <<0x01::4, 0x00::4, 0x0::43>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x01::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4>>) == "cool"
+      assert Trie.get_key(trie, <<0x01::4, 0x00::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x00::4, 0x02::4>>) == "hi"
+      assert Trie.get_key(trie, <<0x01::4, 0x00::4, 0x0::43>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x01::4>>) == nil
     end
 
     test "with encoded nodes", %{db: db} do
@@ -110,27 +110,27 @@ defmodule MerklePatriciaTree.TrieTest do
 
       trie = Trie.new(db, root_hash)
 
-      assert Trie.get(trie, <<0x01::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4>>) == nil
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4>>) == long_string
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4>>) == nil
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4>>) == long_string
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
     end
   end
 
   describe "update trie" do
     test "add a leaf to an empty tree", %{db: db} do
       trie_1 = Trie.new(db)
-      trie_2 = Trie.update(trie_1, <<0x01::4, 0x02::4, 0x03::4>>, "cool")
+      trie_2 = Trie.update_key(trie_1, <<0x01::4, 0x02::4, 0x03::4>>, "cool")
 
-      assert Trie.get(trie_2, <<0x01::4>>) == nil
-      assert Trie.get(trie_2, <<0x01::4, 0x02::4>>) == nil
-      assert Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4>>) == "cool"
-      assert Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
+      assert Trie.get_key(trie_2, <<0x01::4>>) == nil
+      assert Trie.get_key(trie_2, <<0x01::4, 0x02::4>>) == nil
+      assert Trie.get_key(trie_2, <<0x01::4, 0x02::4, 0x03::4>>) == "cool"
+      assert Trie.get_key(trie_2, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
     end
 
     test "from blog post", %{db: db} do
       trie_1 = Trie.new(db)
-      trie_2 = Trie.update(trie_1, <<0x01::4, 0x01::4, 0x02::4>>, "hello")
+      trie_2 = Trie.update_key(trie_1, <<0x01::4, 0x01::4, 0x02::4>>, "hello")
 
       assert trie_2.root_hash ==
                <<73, 98, 206, 73, 94, 192, 23, 36, 174, 248, 169, 73, 103, 133, 200, 167, 68, 83,
@@ -139,9 +139,9 @@ defmodule MerklePatriciaTree.TrieTest do
 
     test "update a leaf value (when stored directly)", %{db: db} do
       trie_1 = Trie.new(db, leaf_node([0x01, 0x02], "first"))
-      trie_2 = Trie.update(trie_1, <<0x01::4, 0x02::4>>, "second")
+      trie_2 = Trie.update_key(trie_1, <<0x01::4, 0x02::4>>, "second")
 
-      assert Trie.get(trie_2, <<0x01::4, 0x02::4>>) == "second"
+      assert Trie.get_key(trie_2, <<0x01::4, 0x02::4>>) == "second"
     end
 
     test "update a leaf value (when stored in ets)", %{db: db} do
@@ -155,39 +155,39 @@ defmodule MerklePatriciaTree.TrieTest do
         |> Storage.store(db)
 
       trie_1 = Trie.new(db, root_hash)
-      trie_2 = Trie.update(trie_1, <<0x01::4, 0x02::4>>, long_string_2)
+      trie_2 = Trie.update_key(trie_1, <<0x01::4, 0x02::4>>, long_string_2)
 
-      assert Trie.get(trie_2, <<0x01::4, 0x02::4>>) == long_string_2
+      assert Trie.get_key(trie_2, <<0x01::4, 0x02::4>>) == long_string_2
     end
 
     test "update branch under ext node", %{db: db} do
       trie_1 =
         db
         |> Trie.new()
-        |> Trie.update(<<0x01::4, 0x02::4>>, "wee")
-        |> Trie.update(<<0x01::4, 0x02::4, 0x03::4>>, "cool")
+        |> Trie.update_key(<<0x01::4, 0x02::4>>, "wee")
+        |> Trie.update_key(<<0x01::4, 0x02::4, 0x03::4>>, "cool")
 
-      trie_2 = Trie.update(trie_1, <<0x01::4, 0x02::4, 0x03::4>>, "cooler")
+      trie_2 = Trie.update_key(trie_1, <<0x01::4, 0x02::4, 0x03::4>>, "cooler")
 
-      assert Trie.get(trie_2, <<0x01::4>>) == nil
-      assert Trie.get(trie_2, <<0x01::4, 0x02::4>>) == "wee"
-      assert Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4>>) == "cooler"
-      assert Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
+      assert Trie.get_key(trie_2, <<0x01::4>>) == nil
+      assert Trie.get_key(trie_2, <<0x01::4, 0x02::4>>) == "wee"
+      assert Trie.get_key(trie_2, <<0x01::4, 0x02::4, 0x03::4>>) == "cooler"
+      assert Trie.get_key(trie_2, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
     end
 
     test "update multiple keys", %{db: db} do
       trie =
         db
         |> Trie.new()
-        |> Trie.update(<<0x01::4, 0x02::4, 0x03::4>>, "a")
-        |> Trie.update(<<0x01::4, 0x02::4, 0x03::4, 0x04::4>>, "b")
-        |> Trie.update(<<0x01::4, 0x02::4, 0x04::4>>, "c")
-        |> Trie.update(<<0x01::size(256)>>, "d")
+        |> Trie.update_key(<<0x01::4, 0x02::4, 0x03::4>>, "a")
+        |> Trie.update_key(<<0x01::4, 0x02::4, 0x03::4, 0x04::4>>, "b")
+        |> Trie.update_key(<<0x01::4, 0x02::4, 0x04::4>>, "c")
+        |> Trie.update_key(<<0x01::size(256)>>, "d")
 
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4>>) == "a"
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == "b"
-      assert Trie.get(trie, <<0x01::4, 0x02::4, 0x04::4>>) == "c"
-      assert Trie.get(trie, <<0x01::size(256)>>) == "d"
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4>>) == "a"
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == "b"
+      assert Trie.get_key(trie, <<0x01::4, 0x02::4, 0x04::4>>) == "c"
+      assert Trie.get_key(trie, <<0x01::size(256)>>) == "d"
     end
 
     test "update a leaf deep in ext nodes", %{db: db} do
@@ -196,30 +196,30 @@ defmodule MerklePatriciaTree.TrieTest do
       trie_1 =
         db
         |> Trie.new()
-        |> Trie.update(<<0x01::4>>, "foo")
-        |> Trie.update(<<0x01::4, 0x01::4>>, "bar")
-        |> Trie.update(<<0x01::4, 0x01::4, 0x01::4, 0x02::4, 0x01::4, 0x03::4>>, "qux")
-        |> Trie.update(key, "corge")
+        |> Trie.update_key(<<0x01::4>>, "foo")
+        |> Trie.update_key(<<0x01::4, 0x01::4>>, "bar")
+        |> Trie.update_key(<<0x01::4, 0x01::4, 0x01::4, 0x02::4, 0x01::4, 0x03::4>>, "qux")
+        |> Trie.update_key(key, "corge")
 
-      trie_2 = Trie.update(trie_1, key, "grault")
+      trie_2 = Trie.update_key(trie_1, key, "grault")
 
-      assert Trie.get(trie_2, key) == "grault"
+      assert Trie.get_key(trie_2, key) == "grault"
     end
 
     test "a root of the trie depends only on the data", %{db: db} do
       trie1 =
         db
         |> Trie.new()
-        |> Trie.update(<<4::4, 2::4, 3::4>>, 1)
-        |> Trie.update(<<4::4, 2::4>>, 2)
-        |> Trie.update(<<4::4, 2::4, 3::4, 8::4>>, 3)
+        |> Trie.update_key(<<4::4, 2::4, 3::4>>, 1)
+        |> Trie.update_key(<<4::4, 2::4>>, 2)
+        |> Trie.update_key(<<4::4, 2::4, 3::4, 8::4>>, 3)
 
       trie2 =
         db
         |> Trie.new()
-        |> Trie.update(<<4::4, 2::4>>, 2)
-        |> Trie.update(<<4::4, 2::4, 3::4, 8::4>>, 3)
-        |> Trie.update(<<4::4, 2::4, 3::4>>, 1)
+        |> Trie.update_key(<<4::4, 2::4>>, 2)
+        |> Trie.update_key(<<4::4, 2::4, 3::4, 8::4>>, 3)
+        |> Trie.update_key(<<4::4, 2::4, 3::4>>, 1)
 
       assert trie2.root_hash == trie1.root_hash
     end
@@ -228,52 +228,52 @@ defmodule MerklePatriciaTree.TrieTest do
       trie =
         db
         |> Trie.new()
-        |> Trie.update(<<5::4, 7::4, 10::4, 15::4, 15::4>>, "a")
-        |> Trie.update(<<5::4, 11::4, 0::4, 0::4, 14::4>>, "b")
-        |> Trie.update(<<5::4, 10::4, 0::4, 0::4, 14::4>>, "c")
-        |> Trie.update(<<4::4, 10::4, 0::4, 0::4, 14::4>>, "d")
-        |> Trie.update(<<5::4, 10::4, 1::4, 0::4, 14::4>>, "e")
+        |> Trie.update_key(<<5::4, 7::4, 10::4, 15::4, 15::4>>, "a")
+        |> Trie.update_key(<<5::4, 11::4, 0::4, 0::4, 14::4>>, "b")
+        |> Trie.update_key(<<5::4, 10::4, 0::4, 0::4, 14::4>>, "c")
+        |> Trie.update_key(<<4::4, 10::4, 0::4, 0::4, 14::4>>, "d")
+        |> Trie.update_key(<<5::4, 10::4, 1::4, 0::4, 14::4>>, "e")
 
-      assert Trie.get(trie, <<5::4, 7::4, 10::4, 15::4, 15::4>>) == "a"
-      assert Trie.get(trie, <<5::4, 11::4, 0::4, 0::4, 14::4>>) == "b"
-      assert Trie.get(trie, <<5::4, 10::4, 0::4, 0::4, 14::4>>) == "c"
-      assert Trie.get(trie, <<4::4, 10::4, 0::4, 0::4, 14::4>>) == "d"
-      assert Trie.get(trie, <<5::4, 10::4, 1::4, 0::4, 14::4>>) == "e"
+      assert Trie.get_key(trie, <<5::4, 7::4, 10::4, 15::4, 15::4>>) == "a"
+      assert Trie.get_key(trie, <<5::4, 11::4, 0::4, 0::4, 14::4>>) == "b"
+      assert Trie.get_key(trie, <<5::4, 10::4, 0::4, 0::4, 14::4>>) == "c"
+      assert Trie.get_key(trie, <<4::4, 10::4, 0::4, 0::4, 14::4>>) == "d"
+      assert Trie.get_key(trie, <<5::4, 10::4, 1::4, 0::4, 14::4>>) == "e"
     end
 
     test "yet another set of updates", %{db: db} do
       trie =
         db
         |> Trie.new()
-        |> Trie.update(
+        |> Trie.update_key(
           <<15::4, 10::4, 5::4, 11::4, 5::4, 2::4, 10::4, 9::4, 6::4, 13::4, 10::4, 3::4, 10::4,
             6::4, 7::4, 1::4>>,
           "a"
         )
-        |> Trie.update(
+        |> Trie.update_key(
           <<15::4, 11::4, 1::4, 14::4, 9::4, 7::4, 9::4, 5::4, 6::4, 15::4, 6::4, 11::4, 8::4,
             5::4, 2::4, 12::4>>,
           "b"
         )
-        |> Trie.update(
+        |> Trie.update_key(
           <<6::4, 1::4, 10::4, 10::4, 5::4, 7::4, 14::4, 3::4, 10::4, 0::4, 15::4, 3::4, 6::4,
             4::4, 5::4, 0::4>>,
           "c"
         )
 
-      assert Trie.get(
+      assert Trie.get_key(
                trie,
                <<15::4, 10::4, 5::4, 11::4, 5::4, 2::4, 10::4, 9::4, 6::4, 13::4, 10::4, 3::4,
                  10::4, 6::4, 7::4, 1::4>>
              ) == "a"
 
-      assert Trie.get(
+      assert Trie.get_key(
                trie,
                <<15::4, 11::4, 1::4, 14::4, 9::4, 7::4, 9::4, 5::4, 6::4, 15::4, 6::4, 11::4,
                  8::4, 5::4, 2::4, 12::4>>
              ) == "b"
 
-      assert Trie.get(
+      assert Trie.get_key(
                trie,
                <<6::4, 1::4, 10::4, 10::4, 5::4, 7::4, 14::4, 3::4, 10::4, 0::4, 15::4, 3::4,
                  6::4, 4::4, 5::4, 0::4>>
@@ -284,35 +284,35 @@ defmodule MerklePatriciaTree.TrieTest do
       trie =
         db
         |> Trie.new()
-        |> Trie.update(
+        |> Trie.update_key(
           <<15::4, 10::4, 5::4, 11::4, 5::4, 2::4, 10::4, 9::4, 6::4, 13::4, 10::4, 3::4, 10::4,
             6::4, 7::4, 1::4>>,
           "a"
         )
-        |> Trie.update(
+        |> Trie.update_key(
           <<15::4, 11::4, 1::4, 14::4, 9::4, 7::4, 9::4, 5::4, 6::4, 15::4, 6::4, 11::4, 8::4,
             5::4, 2::4, 12::4>>,
           "b"
         )
-        |> Trie.update(
+        |> Trie.update_key(
           <<6::4, 1::4, 10::4, 10::4, 5::4, 7::4, 14::4, 3::4, 10::4, 0::4, 15::4, 3::4, 6::4,
             4::4, 5::4, 0::4>>,
           "c"
         )
 
-      assert Trie.get(
+      assert Trie.get_key(
                trie,
                <<15::4, 10::4, 5::4, 11::4, 5::4, 2::4, 10::4, 9::4, 6::4, 13::4, 10::4, 3::4,
                  10::4, 6::4, 7::4, 1::4>>
              ) == "a"
 
-      assert Trie.get(
+      assert Trie.get_key(
                trie,
                <<15::4, 11::4, 1::4, 14::4, 9::4, 7::4, 9::4, 5::4, 6::4, 15::4, 6::4, 11::4,
                  8::4, 5::4, 2::4, 12::4>>
              ) == "b"
 
-      assert Trie.get(
+      assert Trie.get_key(
                trie,
                <<6::4, 1::4, 10::4, 10::4, 5::4, 7::4, 14::4, 3::4, 10::4, 0::4, 15::4, 3::4,
                  6::4, 4::4, 5::4, 0::4>>
@@ -321,12 +321,12 @@ defmodule MerklePatriciaTree.TrieTest do
 
     test "remove branch value", %{db: db} do
       empty_trie = Trie.new(db)
-      trie_1 = Trie.update(empty_trie, <<0x01::4, 0x02::4>>, "foo")
-      trie_2 = Trie.update(trie_1, <<0x01::4, 0x02::4, 0x03::4>>, "bar")
-      trie_3 = Trie.remove(trie_2, <<0x01::4, 0x02::4>>)
+      trie_1 = Trie.update_key(empty_trie, <<0x01::4, 0x02::4>>, "foo")
+      trie_2 = Trie.update_key(trie_1, <<0x01::4, 0x02::4, 0x03::4>>, "bar")
+      trie_3 = Trie.remove_key(trie_2, <<0x01::4, 0x02::4>>)
 
-      assert Trie.get(trie_3, <<0x01::4, 0x02::4>>) == nil
-      assert Trie.get(trie_3, <<0x01::4, 0x02::4, 0x03::4>>) == "bar"
+      assert Trie.get_key(trie_3, <<0x01::4, 0x02::4>>) == nil
+      assert Trie.get_key(trie_3, <<0x01::4, 0x02::4, 0x03::4>>) == "bar"
     end
 
     test "acceptence testing", %{db: db} do
@@ -335,11 +335,11 @@ defmodule MerklePatriciaTree.TrieTest do
           key = random_key()
           value = random_value()
 
-          updated_trie = Trie.update(trie, key, value)
+          updated_trie = Trie.update_key(trie, key, value)
 
           # Verify each key exists in our trie
           for {k, v} <- dict do
-            assert Trie.get(updated_trie, k) == v
+            assert Trie.get_key(updated_trie, k) == v
           end
 
           {updated_trie, [{key, value} | dict]}
@@ -347,6 +347,38 @@ defmodule MerklePatriciaTree.TrieTest do
 
       # next, assert tree is well formed
       assert Verifier.verify_trie(trie, values) == :ok
+    end
+
+    test "creates 2 tries with the same key-value pairs but different insertion order", %{db: db} do
+      key_value_pairs = [
+        {"elixir", "erlang"},
+        {"kotlin", "java"},
+        {"purescript", "javascript"},
+        {"rust", "c++"},
+        {"ruby", "crystal"}
+      ]
+
+      trie1 =
+        Enum.reduce(key_value_pairs, Trie.new(db), fn {lang1, lang2}, trie_acc ->
+          Trie.update_key(trie_acc, lang1, lang2)
+        end)
+
+      trie2 =
+        key_value_pairs
+        |> Enum.reverse()
+        |> Enum.reduce(Trie.new(db), fn {lang1, lang2}, trie_acc ->
+          Trie.update_key(trie_acc, lang1, lang2)
+        end)
+
+      trie3 =
+        key_value_pairs
+        |> Enum.shuffle()
+        |> Enum.reduce(Trie.new(db), fn {lang1, lang2}, trie_acc ->
+          Trie.update_key(trie_acc, lang1, lang2)
+        end)
+
+      assert trie1.root_hash == trie2.root_hash
+      assert trie1.root_hash == trie3.root_hash
     end
   end
 end

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree_test.exs
@@ -29,7 +29,7 @@ defmodule MerklePatriciaTreeTest do
 
         trie =
           Enum.reduce(input, Trie.new(db), fn [k, v], trie ->
-            Trie.update(trie, hex_to_bin(k), hex_to_bin(v))
+            Trie.update_key(trie, hex_to_bin(k), hex_to_bin(v))
           end)
 
         assert trie.root_hash == hex_to_bin(test["root"])


### PR DESCRIPTION
We need at least two levels of cache. Right now we have one level that was implemented in https://github.com/poanetwork/mana/pull/433, https://github.com/poanetwork/mana/pull/441, https://github.com/poanetwork/mana/pull/458. 

Now we're committing changes after every transaction. This is ok if there are no invalid blocks. But in real network we will be receiving invalid blocks and we shouldn't write their transaction data to db. 

The idea is to have `CachingTrie`: all storage modification will be made to in-memory trie and saved to disk after successful block validation. Nodes that are not present in in-memory trie will be read from disk.
This will help to validate state root without saving storage modifications to disk.

This PR implements `CachingTrie`. I will replace regular `Trie` with `CachingTrie` in the next PR

Part of https://github.com/poanetwork/mana/issues/538