### PR TITLE
Better Progress Bar

### DIFF
--- a/apps/cli/lib/sync.ex
+++ b/apps/cli/lib/sync.ex
@@ -85,7 +85,7 @@ defmodule CLI.Sync do
   end
 
   defp track_progress(block_number, max_block_number) do
-    ProgressBar.render(block_number + 1, max_block_number, progress_bar_format())
+    ProgressBar.render(block_number + 1, max_block_number, progress_bar_format(suffix: :count))
   end
 
   @spec progress_bar_format([]) :: []

--- a/apps/cli/mix.exs
+++ b/apps/cli/mix.exs
@@ -32,7 +32,7 @@ defmodule Cli.MixProject do
       {:ethereumex, "~> 0.5.0"},
       {:blockchain, in_umbrella: true},
       {:merkle_patricia_tree, in_umbrella: true},
-      {:progress_bar, "~> 1.6.1"}
+      {:progress_bar, git: "https://github.com/kelvinst/progress_bar.git", branch: "count-suffix"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -25,7 +25,7 @@
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
-  "progress_bar": {:hex, :progress_bar, "1.6.1", "4a82aa4f2b04708dca7472febf5e73477f0e09c81fec98fc502c8d5e3d833172", [:mix], [], "hexpm"},
+  "progress_bar": {:git, "https://github.com/kelvinst/progress_bar.git", "1dc0807ed704b58b1d602644a01dd42e792229da", [branch: "count-suffix"]},
   "rox": {:git, "https://github.com/poanetwork/rox.git", "f763f561780c69d77a62789d0d165af8ae1574bb", [branch: "update-erlang_nif-sys"]},
   "rustler": {:hex, :rustler, "0.18.0", "db4bd0c613d83a1badc31be90ddada6f9821de29e4afd15c53a5da61882e4f2d", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},


### PR DESCRIPTION
This patch adds the CLI patch with a better progress bar (notably, it shows the number of blocks synced, not just a percentage). This currently depends on a third-party GitHub fork, so either we'll wait for that fork to resolve to master or clone it ourselves. In either case, this is a placeholder.