### PR TITLE
Implement Ethash.seed_hash

### DIFF
--- a/apps/blockchain/lib/blockchain/ethash.ex
+++ b/apps/blockchain/lib/blockchain/ethash.ex
@@ -4,6 +4,8 @@ defmodule Blockchain.Ethash do
   yellow paper concerning the Ethash implementation for POW.
   """
 
+  alias ExthCrypto.Hash.Keccak
+
   @j_epoch 30_000
   @j_datasetinit round(:math.pow(2, 30))
   @j_datasetgrowth round(:math.pow(2, 23))
@@ -23,6 +25,8 @@ defmodule Blockchain.Ethash do
                            |> File.read!()
                            |> String.split()
                            |> Enum.map(&String.to_integer/1)
+
+  @first_epoch_seed_hash <<0::256>>
 
   def epoch(block_number) do
     div(block_number, @j_epoch)
@@ -48,6 +52,14 @@ defmodule Blockchain.Ethash do
       @j_cacheinit + @j_cachegrowth * epoch - @j_hashbytes,
       unit_size: @j_hashbytes
     )
+  end
+
+  def seed_hash(block_number) do
+    if epoch(block_number) == 0 do
+      @first_epoch_seed_hash
+    else
+      Keccak.kec(seed_hash(block_number - @j_epoch))
+    end
   end
 
   defp highest_prime_below_threshold(upper_bound, unit_size: unit_size) do

--- a/apps/blockchain/test/blockchain/ethash_test.exs
+++ b/apps/blockchain/test/blockchain/ethash_test.exs
@@ -2,6 +2,7 @@ defmodule Blockchain.EthashTest do
   use ExUnit.Case, async: true
 
   alias Blockchain.Ethash
+  alias ExthCrypto.Hash.Keccak
 
   test "it can calculate the epoch from block number" do
     results =
@@ -40,6 +41,30 @@ defmodule Blockchain.EthashTest do
         |> Enum.map(&Ethash.cache_size/1)
 
       assert results == [16_776_896, 285_081_536]
+    end
+  end
+
+  describe "seed_hash/1" do
+    test "returns the seed hash for block 1" do
+      result = Ethash.seed_hash(1)
+
+      assert result == <<0::256>>
+    end
+
+    test "returns a keccak of the original seed hash for 30000 < block < 60000" do
+      previous_seed_hash = Ethash.seed_hash(1)
+
+      result = Ethash.seed_hash(50_000)
+
+      assert result == Keccak.kec(previous_seed_hash)
+    end
+
+    test "returns a keccak of the previous seed hash for every other block" do
+      previous_seed_hash = Ethash.seed_hash(50_000)
+
+      result = Ethash.seed_hash(70_000)
+
+      assert result == Keccak.kec(previous_seed_hash)
     end
   end
 end


### PR DESCRIPTION
This is part of #541

Description
===========

This implements the `seed_hash/1` function for the `Ethash` algorithm. This particular function can be found in Appendix J, section J.3.1 in the Byzantium Edition of the Yellow Paper.

It's worth noting that previous editions of the yellow paper had the original seed hash as the `keccak(<<0::256>>)` but Geth and Parity has simply used `<<0::256>>` (not the keccak) so that became the canon and is reflected in the Byzantium version of the yellow paper.

See the related issue: https://github.com/ethereum/yellowpaper/issues/312