### PR TITLE
Add Ethash.initial_cache

### DIFF
--- a/apps/blockchain/lib/blockchain/ethash.ex
+++ b/apps/blockchain/lib/blockchain/ethash.ex
@@ -79,4 +79,22 @@ defmodule Blockchain.Ethash do
     |> Enum.find(fn a -> rem(num, a) == 0 end)
     |> is_nil
   end
+
+  @doc """
+  This is the initial cache, c', defined in the Dataset Generation section of
+  Appendix J of the Yellow Paper.
+  """
+  def initial_cache(seed, cache_size) do
+    adjusted_cache_size = div(cache_size, @j_hashbytes)
+
+    for i <- 0..(adjusted_cache_size - 1) do
+      cache_element(i, seed)
+    end
+  end
+
+  def cache_element(0, seed), do: Keccak.kec512(seed)
+
+  def cache_element(element, seed) do
+    Keccak.kec512(cache_element(element - 1, seed))
+  end
 end

--- a/apps/blockchain/test/blockchain/ethash_test.exs
+++ b/apps/blockchain/test/blockchain/ethash_test.exs
@@ -67,4 +67,39 @@ defmodule Blockchain.EthashTest do
       assert result == Keccak.kec(previous_seed_hash)
     end
   end
+
+  describe "initial_cache/3" do
+    test "returns the initial cache for a given cache size" do
+      seed = <<0::256>>
+      # j_hashbytes = 64
+      cache_size = 2 * 64
+      element0 = Keccak.kec512(seed)
+      element1 = Keccak.kec512(element0)
+
+      cache = Ethash.initial_cache(seed, cache_size)
+
+      assert cache == [element0, element1]
+    end
+  end
+
+  describe "cache_element/1" do
+    test "returns the kec 512 of the seed for element 0" do
+      element = 0
+      seed = <<0::256>>
+
+      result = Ethash.cache_element(element, seed)
+
+      assert result == Keccak.kec512(seed)
+    end
+
+    test "returns the kec 512 of the previous element of the cache" do
+      element = 1
+      seed = <<0::256>>
+      previous_element_cache = Keccak.kec512(seed)
+
+      result = Ethash.cache_element(element, seed)
+
+      assert result == Keccak.kec512(previous_element_cache)
+    end
+  end
 end

--- a/apps/exth_crypto/lib/exth_crypto/hash/keccak.ex
+++ b/apps/exth_crypto/lib/exth_crypto/hash/keccak.ex
@@ -31,6 +31,22 @@ defmodule ExthCrypto.Hash.Keccak do
   end
 
   @doc """
+  Returns the keccak sha512 of a given input.
+
+  ## Examples
+
+      iex> ExthCrypto.Hash.Keccak.kec512("hello world")
+      <<62, 226, 180, 0, 71, 184, 6, 15, 104, 198, 114, 66, 23, 86, 96, 244, 23, 77,
+        10, 245, 192, 29, 71, 22, 142, 194, 14, 214, 25, 176, 183, 196, 33, 129, 244,
+        10, 161, 4, 111, 57, 226, 239, 158, 252, 105, 16, 120, 42, 153, 142, 0, 19,
+        209, 114, 69, 137, 87, 149, 127, 172, 148, 5, 182, 125>>
+  """
+  @spec kec(binary()) :: keccak_hash
+  def kec512(data) do
+    :keccakf1600.sha3_512(data)
+  end
+
+  @doc """
   Initializes a new Keccak mac stream.
 
   ## Examples


### PR DESCRIPTION
This is part of #541

Description
===========

Adds the initial cache calculation to `Ethash` algorithm. This is found in Appendix J, section J.3.2, of the Yellow Paper.

The initial cache is an array of of size (cache_size/j_hashytes) where each element is calculated based on the previous element. Each element is encrypted with keccak 512, so we expose that function from ExthCrypto.

YP section
-----------

![screen shot 2018-10-31 at 12 03 03 pm](https://user-images.githubusercontent.com/3245976/47801626-f6802100-dd04-11e8-868b-398d9f39e111.png)
