### PR TITLE
Add build-essential for debian/ubuntu installation

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,15 +8,15 @@ fancy_echo() {
 }
 
 install_linux_deps() {
-  local LINUX_DEPS="automake autoconf autogen libtool gcc curl"
+  local LINUX_DEPS="automake autoconf autogen libtool curl"
   local flavor=`grep "^ID=" /etc/os-release | cut -d"=" -f 2`
   echo $flavor
   case $flavor in
     debian|ubuntu)
-      sudo apt-get install -y $LINUX_DEPS libgmp-dev erlang-dev
+      sudo apt-get install -y $LINUX_DEPS build-essential libgmp-dev erlang-dev
       ;;
     fedora|centos)
-      sudo yum install $LINUX_DEPS gmp-devel
+      sudo yum install $LINUX_DEPS gcc gmp-devel
       ;;
     *)
       fancy_echo "Unrecognized distribution $flavor"


### PR DESCRIPTION
I am not a debian/ubuntu user, but when running the `bin/setup` script in a remote box, the installation failed once because `make` was not available and another time because `c++` was not available (when compiling `rox`).

To fix this, I know we can add the `build-essential` package which includes `make`, `gcc`, and `g++`. I don't believe the same package is available for fedora/centos, so I did not include that package for those two.