### PR TITLE
Simple Sync Script from Release

### DIFF
--- a/apps/cli/lib/config.ex
+++ b/apps/cli/lib/config.ex
@@ -15,6 +15,16 @@ defmodule CLI.Config do
   """
   @spec db_name(atom()) :: nonempty_charlist()
   def db_name(chain_id) do
-    'db/mana-' ++ Atom.to_charlist(chain_id)
+    "db/mana-#{Atom.to_string(chain_id)}"
+    |> relative_to_pwd()
+    |> String.to_charlist()
+  end
+
+  @spec relative_to_pwd(String.t()) :: String.t()
+  defp relative_to_pwd(rel) do
+    Path.join(
+      System.cwd!(),
+      "/../../../../#{rel}"
+    )
   end
 end

--- a/rel/commands/sync.sh
+++ b/rel/commands/sync.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+release="_build/dev/rel/mana/bin/mana"
+$release eval --mfa "Mix.Tasks.Sync.run/1" --argv -- "$@"


### PR DESCRIPTION
This patch adds a simple script on how to run sync after building a release. There's work to do to get these scripts running correctly in all environments, but this should be the easiest / most straight-forward process for calling into the CLI from a release. The framework comes from [distrillery - migrations](https://github.com/bitwalker/distillery/blob/master/docs/guides/running_migrations.md#custom-command). The biggest open issue is getting the correct build artifact (currently the $release var in the script and correct rocks db filename (currently a relative in CLI.Config).

You can run, for example:

```bash
rel/commands/sync.sh --chain ropsten
```