### PR TITLE
Storage optimisations

### DIFF
--- a/apps/cli/lib/sync.ex
+++ b/apps/cli/lib/sync.ex
@@ -11,7 +11,7 @@ defmodule CLI.Sync do
 
   @type block_limit :: integer() | :infinite
 
-  @save_block_interval 100
+  @save_block_interval 1000
 
   @doc """
   Recursively adds blocks to a tree. This function will

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
@@ -199,11 +199,9 @@ defmodule MerklePatriciaTree.CachingTrie do
         end
       end)
 
-    caching_trie.db_changes
-    |> Map.to_list()
-    |> Enum.each(fn {key, value} ->
-      TrieStorage.put_raw_key!(updated_trie, key, value)
-    end)
+    db_updates = Map.to_list(caching_trie.db_changes)
+
+    TrieStorage.put_batch_raw_keys!(updated_trie, db_updates)
 
     new(updated_trie)
   end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
@@ -209,6 +209,15 @@ defmodule MerklePatriciaTree.CachingTrie do
   end
 
   @impl true
+  def put_batch_raw_keys!(caching_trie, key_value_pairs) do
+    updates = Map.new(key_value_pairs)
+
+    updated_db_changes = Map.merge(caching_trie.db_changes, updates)
+
+    %{caching_trie | db_changes: updated_db_changes}
+  end
+
+  @impl true
   def store(caching_trie) do
     in_memory_trie = caching_trie.in_memory_trie
 

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db.ex
@@ -20,6 +20,8 @@ defmodule MerklePatriciaTree.DB do
   @callback init(db_name) :: db
   @callback get(db_ref, MerklePatriciaTree.Trie.key()) :: {:ok, value} | :not_found
   @callback put!(db_ref, MerklePatriciaTree.Trie.key(), value) :: :ok
+  @callback delete!(db_ref(), MerklePatriciaTree.Trie.key()) :: :ok
+  @callback batch_put!(db_ref, [{MerklePatriciaTree.Trie.key(), value}]) :: :ok
 
   @doc """
   Retrieves a key from the database.
@@ -95,5 +97,13 @@ defmodule MerklePatriciaTree.DB do
   @spec delete!(db_ref(), MerklePatriciaTree.Trie.key()) :: :ok
   def delete!(_db = {db_mod, db_ref}, key) do
     db_mod.delete!(db_ref, key)
+  end
+
+  @doc """
+  Stores key-value pairs in the database.
+  """
+  @spec batch_put!(db_ref, [{MerklePatriciaTree.Trie.key(), value}]) :: :ok
+  def batch_put!(_db = {db_mod, db_ref}, key_value_pairs) do
+    db_mod.batch_put!(db_ref, key_value_pairs)
   end
 end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/ets.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/ets.ex
@@ -4,14 +4,12 @@ defmodule MerklePatriciaTree.DB.ETS do
   is backed by :ets.
   """
 
-  alias MerklePatriciaTree.{DB, Trie}
-
   @behaviour MerklePatriciaTree.DB
 
   @doc """
   Performs initialization for this db.
   """
-  @spec init(DB.db_name()) :: DB.db()
+  @impl true
   def init(db_name) do
     :ets.new(db_name, [:set, :public, :named_table])
 
@@ -21,7 +19,7 @@ defmodule MerklePatriciaTree.DB.ETS do
   @doc """
   Retrieves a key from the database.
   """
-  @spec get(DB.db_ref(), Trie.key()) :: {:ok, DB.value()} | :not_found
+  @impl true
   def get(db_ref, key) do
     case :ets.lookup(db_ref, key) do
       [{^key, v} | _rest] -> {:ok, v}
@@ -32,7 +30,7 @@ defmodule MerklePatriciaTree.DB.ETS do
   @doc """
   Stores a key in the database.
   """
-  @spec put!(DB.db_ref(), Trie.key(), DB.value()) :: :ok
+  @impl true
   def put!(db_ref, key, value) do
     case :ets.insert(db_ref, {key, value}) do
       true -> :ok
@@ -42,9 +40,19 @@ defmodule MerklePatriciaTree.DB.ETS do
   @doc """
   Removes all objects with key from the database.
   """
-  @spec delete!(DB.db_ref(), Trie.key()) :: :ok
+  @impl true
   def delete!(db_ref, key) do
     case :ets.delete(db_ref, key) do
+      true -> :ok
+    end
+  end
+
+  @doc """
+  Stores key-value pairs in the database.
+  """
+  @impl true
+  def batch_put!(db_ref, key_value_pairs) do
+    case :ets.insert(db_ref, key_value_pairs) do
       true -> :ok
     end
   end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/rocksdb.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/rocksdb.ex
@@ -49,6 +49,8 @@ defmodule MerklePatriciaTree.DB.RocksDB do
       :ok = :rocksdb.batch_put(batch, key, value)
     end)
 
-    :rocksdb.write_batch(db_ref, batch, [])
+    :ok = :rocksdb.write_batch(db_ref, batch, [])
+
+    :ok
   end
 end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/rocksdb.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/rocksdb.ex
@@ -4,14 +4,12 @@ defmodule MerklePatriciaTree.DB.RocksDB do
   is backed by rocksdb.
   """
 
-  alias MerklePatriciaTree.{DB, Trie}
-
   @behaviour MerklePatriciaTree.DB
 
   @doc """
   Performs initialization for this db.
   """
-  @spec init(DB.db_name()) :: DB.db()
+  @impl true
   def init(db_name) do
     {:ok, db_ref} = :rocksdb.open(db_name, create_if_missing: true)
 
@@ -21,22 +19,38 @@ defmodule MerklePatriciaTree.DB.RocksDB do
   @doc """
   Retrieves a key from the database.
   """
-  @spec get(DB.db_ref(), Trie.key()) :: {:ok, DB.value()} | :not_found
+  @impl true
   def get(db_ref, key), do: :rocksdb.get(db_ref, key, [])
 
   @doc """
   Stores a key in the database.
   """
-  @spec put!(DB.db_ref(), Trie.key(), DB.value()) :: :ok
+  @impl true
   def put!(db_ref, key, value), do: :rocksdb.put(db_ref, key, value, [])
 
   @doc """
   Removes all objects with key from the database.
   """
-  @spec delete!(DB.db_ref(), Trie.key()) :: :ok
+  @impl true
   def delete!(db_ref, key) do
     case :rocksdb.delete(db_ref, key, []) do
       :ok -> :ok
     end
+  end
+
+  @doc """
+  Stores key-value pairs in the database.
+  """
+  @impl true
+  def batch_put!(db_ref, key_value_pairs) do
+    {:ok, batch} = :rocksdb.batch()
+
+    Enum.each(key_value_pairs, fn {key, value} ->
+      :ok = :rocksdb.batch_put(batch, key, value)
+    end)
+
+    :ok = :rocksdb.write_batch(db_ref, batch, [])
+
+    :ok
   end
 end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/rocksdb.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/rocksdb.ex
@@ -49,8 +49,6 @@ defmodule MerklePatriciaTree.DB.RocksDB do
       :ok = :rocksdb.batch_put(batch, key, value)
     end)
 
-    :ok = :rocksdb.write_batch(db_ref, batch, [])
-
-    :ok
+    :rocksdb.write_batch(db_ref, batch, [])
   end
 end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
@@ -157,14 +157,19 @@ defmodule MerklePatriciaTree.Trie do
 
   @impl true
   def put_raw_key!(trie, key, value) do
-    MerklePatriciaTree.DB.put!(trie.db, key, value)
+    DB.put!(trie.db, key, value)
 
     trie
   end
 
   @impl true
+  def put_batch_raw_keys!(trie, key_value_pairs) do
+    DB.batch_put!(trie.db, key_value_pairs)
+  end
+
+  @impl true
   def get_raw_key(trie, key) do
-    MerklePatriciaTree.DB.get(trie.db, key)
+    DB.get(trie.db, key)
   end
 
   @impl true

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
@@ -165,6 +165,8 @@ defmodule MerklePatriciaTree.Trie do
   @impl true
   def put_batch_raw_keys!(trie, key_value_pairs) do
     DB.batch_put!(trie.db, key_value_pairs)
+
+    trie
   end
 
   @impl true

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie_storage.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie_storage.ex
@@ -23,6 +23,8 @@ defmodule MerklePatriciaTree.TrieStorage do
 
   @callback put_raw_key!(t(), binary(), binary()) :: t()
 
+  @callback put_batch_raw_keys!(t(), [{binary(), binary()}]) :: t()
+
   @callback get_raw_key(t(), binary()) :: {:ok, binary()} | :not_found
 
   @callback get_key(t(), Trie.key()) :: nil | binary()
@@ -67,6 +69,10 @@ defmodule MerklePatriciaTree.TrieStorage do
 
   def put_raw_key!(implementation, key, value) do
     storage(implementation).put_raw_key!(implementation, key, value)
+  end
+
+  def put_batch_raw_keys!(implementation, pairs) do
+    storage(implementation).put_batch_raw_keys!(implementation, pairs)
   end
 
   def get_raw_key(implementation, key) do

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
@@ -122,14 +122,6 @@ defmodule MerklePatriciaTree.CachingTrieTest do
 
       assert CachingTrie.get_key(subtrie, "rust") == "c++"
 
-      trie_changes = [
-        {:update, disk_trie.root_hash, "elixir", "erlang"},
-        {:update, Trie.empty_trie_root_hash(), "rust", "c++"}
-      ]
-
-      assert subtrie.trie_changes == trie_changes
-      assert updated_caching_trie.trie_changes == trie_changes
-
       assert updated_caching_trie.in_memory_trie.root_hash ==
                caching_trie.in_memory_trie.root_hash
     end

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
@@ -290,4 +290,24 @@ defmodule MerklePatriciaTree.CachingTrieTest do
       assert Trie.get_raw_key(disk_trie, "elixir") == {:ok, "erlang"}
     end
   end
+
+  describe "put_batch_raw_keys!/2" do
+    test "puts a batch of keys to db_changes", %{disk_trie: disk_trie} do
+      caching_trie = CachingTrie.new(disk_trie)
+
+      pairs = [
+        {"elixir", "erlang"},
+        {"rust", "c++"},
+        {"ruby", "crystal"}
+      ]
+
+      updated_caching_trie = CachingTrie.put_batch_raw_keys!(caching_trie, pairs)
+
+      assert updated_caching_trie.db_changes == %{
+               "elixir" => "erlang",
+               "ruby" => "crystal",
+               "rust" => "c++"
+             }
+    end
+  end
 end

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/ets_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/ets_test.exs
@@ -3,36 +3,68 @@ defmodule MerklePatriciaTree.DB.ETSTest do
   alias MerklePatriciaTree.DB
   alias MerklePatriciaTree.DB.ETS
 
-  test "init creates an ets table" do
-    {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+  describe "init/1" do
+    test "init creates an ets table" do
+      {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
 
-    :ets.insert(db_ref, {"key", "value"})
-    assert :ets.lookup(db_ref, "key") == [{"key", "value"}]
-  end
+      ETS.put!(db_ref, "key", "value")
 
-  test "get/1" do
-    {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
-
-    :ets.insert(db_ref, {"key", "value"})
-    assert ETS.get(db_ref, "key") == {:ok, "value"}
-    assert ETS.get(db_ref, "key2") == :not_found
-  end
-
-  test "get!/1" do
-    db = {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
-
-    :ets.insert(db_ref, {"key", "value"})
-    assert DB.get!(db, "key") == "value"
-
-    assert_raise MerklePatriciaTree.DB.KeyNotFoundError, "cannot find key `key2`", fn ->
-      DB.get!(db, "key2")
+      assert ETS.get(db_ref, "key") == {:ok, "value"}
     end
   end
 
-  test "put!/2" do
-    {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+  describe "get/1" do
+    test "gets value from db" do
+      {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
 
-    assert ETS.put!(db_ref, "key", "value") == :ok
-    assert :ets.lookup(db_ref, "key") == [{"key", "value"}]
+      ETS.put!(db_ref, "key", "value")
+
+      assert ETS.get(db_ref, "key") == {:ok, "value"}
+      assert ETS.get(db_ref, "key2") == :not_found
+    end
+  end
+
+  describe "get!/1" do
+    test "fails to get value from db" do
+      db = {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+
+      ETS.put!(db_ref, "key", "value")
+      assert DB.get!(db, "key") == "value"
+
+      assert_raise MerklePatriciaTree.DB.KeyNotFoundError, "cannot find key `key2`", fn ->
+        DB.get!(db, "key2")
+      end
+    end
+  end
+
+  describe "put!/3" do
+    test "puts value to db" do
+      {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+
+      assert ETS.put!(db_ref, "key", "value") == :ok
+      assert ETS.get(db_ref, "key") == {:ok, "value"}
+    end
+  end
+
+  describe "batch_put!/2" do
+    test "puts key value pairs to db" do
+      {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+
+      pairs = [
+        {"elixir", "erlang"},
+        {"rust", "c++"},
+        {"ruby", "crystal"}
+      ]
+
+      Enum.each(pairs, fn {key, _value} ->
+        assert ETS.get(db_ref, key) == :not_found
+      end)
+
+      assert ETS.batch_put!(db_ref, pairs) == :ok
+
+      Enum.each(pairs, fn {key, value} ->
+        assert ETS.get(db_ref, key) == {:ok, value}
+      end)
+    end
   end
 end

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/rocksdb_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/rocksdb_test.exs
@@ -4,52 +4,84 @@ defmodule MerklePatriciaTree.DB.RocksDBTest do
   alias MerklePatriciaTree.DB
   alias MerklePatriciaTree.DB.RocksDB
 
-  test "init creates a rocksdb file" do
-    db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+  describe "init/1" do
+    test "init creates a rocksdb file" do
+      db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
 
-    :rocksdb.open(db_name, create_if_missing: true)
-    # There is no `close` function in RocksDB API (for now),
-    # This means that we can't just close and re-open the db again.
-    # Also we can not open it twice at the same time (it'll be in the locked state).
-    # So we just check if the db file exists. This should be enough.
-    assert File.exists?(db_name)
-  end
-
-  test "get/1" do
-    db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
-    {_, db_ref} = :rocksdb.open(db_name, create_if_missing: true)
-
-    :rocksdb.put(db_ref, "key", "value", [])
-    assert :rocksdb.get(db_ref, "key", []) == {:ok, "value"}
-    assert :rocksdb.get(db_ref, "key2", []) == :not_found
-  end
-
-  test "get!/1" do
-    db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
-    {_, db_ref} = :rocksdb.open(db_name, create_if_missing: true)
-
-    :rocksdb.put(db_ref, "key", "value", [])
-    assert DB.get!({RocksDB, db_ref}, "key") == "value"
-
-    assert_raise MerklePatriciaTree.DB.KeyNotFoundError, "cannot find key `key2`", fn ->
-      DB.get!({RocksDB, db_ref}, "key2")
+      RocksDB.init(db_name)
+      # There is no `close` function in RocksDB API (for now),
+      # This means that we can't just close and re-open the db again.
+      # Also we can not open it twice at the same time (it'll be in the locked state).
+      # So we just check if the db file exists. This should be enough.
+      assert File.exists?(db_name)
     end
   end
 
-  test "put/3" do
-    db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
-    {_, db_ref} = :rocksdb.open(db_name, create_if_missing: true)
+  describe "get/1" do
+    test "gets value from db" do
+      db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+      {_, db_ref} = RocksDB.init(db_name)
 
-    assert :rocksdb.put(db_ref, "key", "value", []) == :ok
-    assert :rocksdb.get(db_ref, "key", []) == {:ok, "value"}
+      RocksDB.put!(db_ref, "key", "value")
+
+      assert RocksDB.get(db_ref, "key") == {:ok, "value"}
+      assert RocksDB.get(db_ref, "key2") == :not_found
+    end
   end
 
-  test "simple open, put, get" do
-    db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
-    {_, db_ref} = :rocksdb.open(db_name, create_if_missing: true)
+  describe "get!/1" do
+    test "fails to get value from db" do
+      db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+      {_, db_ref} = :rocksdb.open(db_name, create_if_missing: true)
 
-    assert :rocksdb.put(db_ref, "name", "bob", []) == :ok
-    assert DB.get!({RocksDB, db_ref}, "name") == "bob"
-    assert :rocksdb.get(db_ref, "age", []) == :not_found
+      RocksDB.put!(db_ref, "key", "value")
+      assert DB.get!({RocksDB, db_ref}, "key") == "value"
+
+      assert_raise MerklePatriciaTree.DB.KeyNotFoundError, "cannot find key `key2`", fn ->
+        DB.get!({RocksDB, db_ref}, "key2")
+      end
+    end
+  end
+
+  describe "put/3" do
+    test "puts value to db" do
+      db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+      {_, db_ref} = RocksDB.init(db_name)
+
+      assert RocksDB.put!(db_ref, "key", "value") == :ok
+      assert RocksDB.get(db_ref, "key") == {:ok, "value"}
+    end
+
+    test "simple open, put, get" do
+      db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+      {_, db_ref} = RocksDB.init(db_name)
+
+      assert RocksDB.put!(db_ref, "name", "bob") == :ok
+      assert DB.get!({RocksDB, db_ref}, "name") == "bob"
+      assert RocksDB.get(db_ref, "age") == :not_found
+    end
+  end
+
+  describe "batch_put!/2" do
+    test "puts key-value pairs to db" do
+      db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+      {_db, db_ref} = RocksDB.init(db_name)
+
+      pairs = [
+        {"elixir", "erlang"},
+        {"rust", "c++"},
+        {"ruby", "crystal"}
+      ]
+
+      Enum.each(pairs, fn {key, _value} ->
+        assert RocksDB.get(db_ref, key) == :not_found
+      end)
+
+      assert RocksDB.batch_put!(db_ref, pairs) == :ok
+
+      Enum.each(pairs, fn {key, value} ->
+        assert RocksDB.get(db_ref, key) == {:ok, value}
+      end)
+    end
   end
 end

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/trie_test.exs
@@ -421,4 +421,26 @@ defmodule MerklePatriciaTree.TrieTest do
       assert Trie.get_raw_key(updated_trie, "5") == :not_found
     end
   end
+
+  describe "put_batch_raw_keys!/2" do
+    test "saves key-value pairs to db" do
+      trie = MerklePatriciaTree.Test.random_ets_db() |> Trie.new()
+
+      pairs = [
+        {"elixir", "erlang"},
+        {"rust", "c++"},
+        {"ruby", "crystal"}
+      ]
+
+      Enum.each(pairs, fn {key, _value} ->
+        assert Trie.get_raw_key(trie, key) == :not_found
+      end)
+
+      Trie.put_batch_raw_keys!(trie, pairs)
+
+      Enum.each(pairs, fn {key, value} ->
+        assert Trie.get_raw_key(trie, key) == {:ok, value}
+      end)
+    end
+  end
 end

--- a/bin/setup
+++ b/bin/setup
@@ -35,14 +35,6 @@ brew "libtool"
 EOF
 }
 
-install_rust() {
-  curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
-  if [ $? -ne 0 ]; then
-    fancy_echo "Rust installation failed"
-    exit 1
-  fi
-}
-
 install_deps() {
   local sys=`uname -s`
   echo $sys
@@ -94,24 +86,11 @@ if ! command -v mix > /dev/null; then
   exit 1
 fi
 
-if ! command -v rustc > /dev/null; then
-  fancy_echo "It looks like you don't have Rust installed. We'll install that for you."
-  install_rust
-fi
-
 fancy_echo "Installing elixir dependencies and compiling."
 mix local.hex --force
 mix local.rebar --force
 
-if ! command -v rebar > /dev/null; then
-  fancy_echo "\`rebar\`: Command not found"
-  fancy_echo "Please either add ~/.mix to your \$PATH environemnt varible or install it with brew: \`brew install rebar\`"
-  exit 1
-fi
-
 mix deps.get
-
-cd deps/libsecp256k1 && rebar compile && cd ../..
 
 mix compile
 


### PR DESCRIPTION
Optimisations:
- we can optimize writing  key-value pairs (`{block_hash, block}`, `{account_code_hash, account_code}` etc) when committing raw in-memory cache (simple map of key-value pairs) by using batch updates
- instead of updating permanent trie by traversing Merkle Trie we can insert data from in-memory-trie by fetching all key-value pairs from ets table 

Resolves https://github.com/mana-ethereum/mana/issues/559 https://github.com/mana-ethereum/mana/issues/538