### PR TITLE
 Precompute `valid_jump_destinations`

### DIFF
--- a/apps/evm/lib/evm/machine_code.ex
+++ b/apps/evm/lib/evm/machine_code.ex
@@ -31,38 +31,7 @@ defmodule EVM.MachineCode do
   end
 
   @doc """
-  Returns true if the given new program_counter is a valid jump
-  destination for the machine code, false otherwise.
-
-  TODO: Memoize
-
-  ## Examples
-
-      iex> EVM.MachineCode.valid_jump_dest?(0, EVM.MachineCode.compile([:push1, 3, :push1, 5, :jumpdest, :add, :return, :jumpdest, :stop]))
-      false
-
-      iex> EVM.MachineCode.valid_jump_dest?(4, EVM.MachineCode.compile([:push1, 3, :push1, 5, :jumpdest, :add, :return, :jumpdest, :stop]))
-      true
-
-      iex> EVM.MachineCode.valid_jump_dest?(6, EVM.MachineCode.compile([:push1, 3, :push1, 5, :jumpdest, :add, :return, :jumpdest, :stop]))
-      false
-
-      iex> EVM.MachineCode.valid_jump_dest?(7, EVM.MachineCode.compile([:push1, 3, :push1, 5, :jumpdest, :add, :return, :jumpdest, :stop]))
-      true
-
-      iex> EVM.MachineCode.valid_jump_dest?(100, EVM.MachineCode.compile([:push1, 3, :push1, 5, :jumpdest, :add, :return, :jumpdest, :stop]))
-      false
-  """
-  @spec valid_jump_dest?(MachineState.program_counter(), t) :: boolean()
-  def valid_jump_dest?(program_counter, machine_code) do
-    # TODO: This should be sorted for quick lookup
-    Enum.member?(machine_code |> valid_jump_destinations, program_counter)
-  end
-
-  @doc """
   Returns the legal jump locations in the given machine code.
-
-  TODO: Memoize
 
   ## Example
 

--- a/apps/evm/lib/evm/machine_state.ex
+++ b/apps/evm/lib/evm/machine_state.ex
@@ -6,11 +6,12 @@ defmodule EVM.MachineState do
   This is most often seen as µ in the Yellow Paper.
   """
 
-  alias EVM.{Gas, MachineState, ProgramCounter, Stack}
   alias EVM.Operation.Metadata
+  alias EVM.{Gas, MachineState, ProgramCounter, Stack}
 
   defstruct gas: nil,
             program_counter: 0,
+            valid_jump_destinations: [],
             memory: <<>>,
             active_words: 0,
             previously_active_words: 0,

--- a/apps/evm/lib/evm/vm.ex
+++ b/apps/evm/lib/evm/vm.ex
@@ -36,6 +36,7 @@ defmodule EVM.VM do
   def run(gas, exec_env) do
     machine_state = %MachineState{gas: gas}
     sub_state = %SubState{}
+    exec_env = ExecEnv.set_valid_jump_destinations(exec_env)
 
     {n_machine_state, n_sub_state, n_exec_env, output} = exec(machine_state, sub_state, exec_env)
 


### PR DESCRIPTION
Before we would calculate `valid_jump_destinations` on every call to
`valid_jump_dest?`. Now we calculate it once ahead of time.