### PR TITLE
fix initial storage value for EIP1283 sstore gas cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Ethereum common tests are created for all clients to test against. We plan to pr
 | TangerineWhistle  | 100% (1262/1262)          | 100% (1112/1112)            | ✓         |
 | SpuriousDragon    | 100% (1193/1193)          | 100% (1172/1172)            | ✓         |
 | Byzantium         | 100% (4945/4945)          | 100% (4790/4790)            | ✓         |
-| Constantinople    | 100% (5369/5369)          | 100% (5331/5331)            |           |
+| Constantinople    | 100% (5369/5369)          | 100% (5331/5331)            | ✓         |
 
 View the community [Constantinople Project Tracker](https://github.com/ethereum/pm/issues/53).
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Ethereum common tests are created for all clients to test against. We plan to pr
 | TangerineWhistle  | 100% (1262/1262)          | 100% (1112/1112)            | ✓         |
 | SpuriousDragon    | 100% (1193/1193)          | 100% (1172/1172)            | ✓         |
 | Byzantium         | 100% (4945/4945)          | 100% (4790/4790)            | ✓         |
-| Constantinople    | 99.9% (5363/5369)         | 99.9% (5325/5331)           |           |
+| Constantinople    | 100% (5369/5369)          | 100% (5331/5331)            |           |
 
 View the community [Constantinople Project Tracker](https://github.com/ethereum/pm/issues/53).
 

--- a/apps/blockchain/lib/blockchain/account/repo.ex
+++ b/apps/blockchain/lib/blockchain/account/repo.ex
@@ -366,8 +366,13 @@ defmodule Blockchain.Account.Repo do
     cached_value = Cache.initial_value(account_repo.cache, address, key)
 
     case cached_value do
-      nil -> Account.get_storage(account_repo.state, address, key)
-      _ -> {:ok, cached_value}
+      nil ->
+        account = account(account_repo, address)
+
+        Account.get_storage(account_repo.state, account, key)
+
+      _ ->
+        {:ok, cached_value}
     end
   end
 

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -7,11 +7,7 @@ defmodule Blockchain.StateTest do
 
   @failing_tests %{
     "Byzantium" => [],
-    "Constantinople" => [
-      "stCreate2/RevertInCreateInInitCreate2",
-      "stRevertTest/RevertInCreateInInit",
-      "stSStoreTest/InitCollision"
-    ],
+    "Constantinople" => [],
     "Frontier" => [],
     "Homestead" => [],
     "SpuriousDragon" => [],

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -16,14 +16,7 @@ defmodule BlockchainTest do
     "TangerineWhistle" => [],
     "SpuriousDragon" => [],
     "Byzantium" => [],
-    "Constantinople" => [
-      "GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json",
-      "GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json",
-      "GeneralStateTests/stSStoreTest/InitCollision_d0g0v0.json",
-      "GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json",
-      "GeneralStateTests/stSStoreTest/InitCollision_d2g0v0.json",
-      "GeneralStateTests/stSStoreTest/InitCollision_d3g0v0.json"
-    ],
+    "Constantinople" => [],
     # the rest are not implemented yet
     "EIP158ToByzantiumAt5" => [],
     "FrontierToHomesteadAt5" => [],

--- a/apps/evm/lib/evm/account_repo.ex
+++ b/apps/evm/lib/evm/account_repo.ex
@@ -48,8 +48,8 @@ defmodule EVM.AccountRepo do
               EVM.address() | nil,
               EVM.Configuration.t()
             ) ::
-              {:error, {t, EVM.Gas.t(), EVM.SubState.t()}, <<>> | binary()}
-              | {:ok, {t, EVM.Gas.t(), EVM.SubState.t()}, <<>>}
+              {:error, {t, EVM.Gas.t(), EVM.SubState.t(), <<>> | binary()}}
+              | {:ok, {t, EVM.Gas.t(), EVM.SubState.t(), <<>>}}
 
   @doc "Sets the balance of the account at the given address to zero"
   @callback clear_balance(t, EVM.address()) :: t


### PR DESCRIPTION
We should reset storage for newly created accounts. We were
resetting them in the evm cache but we were reading initial values
from the permanent storage. We should read them from the cache

fixes https://github.com/mana-ethereum/mana/issues/575 https://github.com/mana-ethereum/mana/issues/534

related https://gist.github.com/holiman/0154f00d5fcec5f89e85894cbb46fcb2