### PR TITLE
Extract EvmTestRunner to run common_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,21 +14,21 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
 
@@ -37,41 +37,41 @@ jobs:
           no_output_timeout: 2400
 
       - save_cache:
-          key: v6-env-cache-{{ arch }}-{{ .Branch }}
+          key: v7-env-cache-{{ arch }}-{{ .Branch }}
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v6-env-cache-{{ .Branch }}
+          key: v7-env-cache-{{ .Branch }}
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v6-env-cache
+          key: v7-env-cache
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "deps"
       - save_cache:
-          key: v6-mix-cache-{{ .Branch }}
+          key: v7-mix-cache-{{ .Branch }}
           paths: "deps"
       - save_cache:
-          key: v6-mix-cache
+          key: v7-mix-cache
           paths: "deps"
 
       - save_cache:
-          key: v6-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: v7-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "_build"
       - save_cache:
-          key: v6-build-cache-{{ .Branch }}
+          key: v7-build-cache-{{ .Branch }}
           paths: "_build"
       - save_cache:
-          key: v6-build-cache
+          key: v7-build-cache
           paths: "_build"
 
       - run:
@@ -116,20 +116,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - run: mix test --exclude pending
 
@@ -150,20 +150,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include Frontier
 
@@ -184,20 +184,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include Homestead
 
@@ -218,20 +218,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include HomesteadToDaoAt5
 
@@ -252,20 +252,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include TangerineWhistle
 
@@ -286,20 +286,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include SpuriousDragon
 
@@ -320,20 +320,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include Byzantium
 
@@ -354,20 +354,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - run:
           command: mix cmd --app blockchain mix test --exclude test --include Constantinople
@@ -393,26 +393,26 @@ jobs:
 
       - restore_cache:
           keys:
-            - v6-build-cache-{{ .Branch }}
-            - v6-build-cache
+            - v7-build-cache-{{ .Branch }}
+            - v7-build-cache
 
       - restore_cache:
           keys:
-            - v6-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v6-mix-cache-{{ .Branch }}
-            - v6-mix-cache
+            - v7-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v7-mix-cache-{{ .Branch }}
+            - v7-mix-cache
 
       - restore_cache:
           keys:
-            - v6-env-cache-{{ arch }}-{{ .Branch }}
-            - v6-env-cache-{{ .Branch }}
-            - v6-env-cache
+            - v7-env-cache-{{ arch }}-{{ .Branch }}
+            - v7-env-cache-{{ .Branch }}
+            - v7-env-cache
 
       - restore_cache:
           keys:
-            - v6-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
-            - v6-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
-            - v6-plt-cache-{{ ".tool-versions" }}
+            - v7-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+            - v7-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+            - v7-plt-cache-{{ ".tool-versions" }}
 
       - run:
           name: Unpack PLT cache
@@ -432,17 +432,17 @@ jobs:
             cp ~/.mix/dialyxir*.plt plts/
 
       - save_cache:
-          key: v6-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+          key: v7-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
           paths:
             - plts
 
       - save_cache:
-          key: v6-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+          key: v7-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
           paths:
             - plts
 
       - save_cache:
-          key: v6-plt-cache-{{ ".tool-versions" }}
+          key: v7-plt-cache-{{ ".tool-versions" }}
           paths:
             - plts
 

--- a/apps/evm/mix.exs
+++ b/apps/evm/mix.exs
@@ -50,6 +50,7 @@ defmodule EVM.Mixfile do
       {:merkle_patricia_tree, in_umbrella: true},
       {:exth_crypto, in_umbrella: true},
       {:ex_rlp, "~> 0.3.1"},
+      {:jason, "~> 1.1", test: true},
       {:bn, "~> 0.2.1"}
     ]
   end

--- a/apps/evm/test/evm_test.exs
+++ b/apps/evm/test/evm_test.exs
@@ -1,7 +1,7 @@
 defmodule EvmTest do
   import ExthCrypto.Math, only: [hex_to_bin: 1, hex_to_int: 1]
 
-  alias EVM.Mock.{MockAccountRepo, MockBlockHeaderInfo}
+  alias EVM.TestRunner
   alias ExthCrypto.Hash.Keccak
 
   use ExUnit.Case, async: true
@@ -36,7 +36,7 @@ defmodule EvmTest do
       # :"loop-exp-1b-1M",
       # :"loop-exp-32b-100k",
       # :"loop-exp-8b-100k",
-      # :"loop-mul",
+      # :"loop-mul"
     ],
     i_oand_flow_operations: :all,
     system_operations: :all,
@@ -46,7 +46,7 @@ defmodule EvmTest do
   test "Ethereum Common Tests" do
     for {test_group_name, _test_group} <- @passing_tests_by_group do
       for {test_name, test} <- passing_tests(test_group_name) do
-        {gas, sub_state, exec_env, _} = run_test(test)
+        {gas, sub_state, exec_env, _} = TestRunner.run(test)
 
         context = %{
           test_name: test_name,
@@ -70,113 +70,6 @@ defmodule EvmTest do
         end
       end
     end
-  end
-
-  defp run_test(test) do
-    exec_env = get_exec_env(test)
-    gas = hex_to_int(test["exec"]["gas"])
-    EVM.VM.run(gas, exec_env)
-  end
-
-  defp get_exec_env(test) do
-    account_repo = account_repo(test)
-
-    %EVM.ExecEnv{
-      account_repo: account_repo,
-      address: hex_to_bin(test["exec"]["address"]),
-      block_header_info: block_header_info(test),
-      data: hex_to_bin(test["exec"]["data"]),
-      gas_price: hex_to_bin(test["exec"]["gasPrice"]),
-      machine_code: hex_to_bin(test["exec"]["code"]),
-      originator: hex_to_bin(test["exec"]["origin"]),
-      sender: hex_to_bin(test["exec"]["caller"]),
-      value_in_wei: hex_to_bin(test["exec"]["value"])
-    }
-  end
-
-  def account_repo(test) do
-    account_map = %{
-      hex_to_bin(test["exec"]["caller"]) => %{
-        balance: 0,
-        code: <<>>,
-        nonce: 0,
-        storage: %{}
-      }
-    }
-
-    account_map =
-      Enum.reduce(test["pre"], account_map, fn {address, account}, address_map ->
-        storage =
-          account["storage"]
-          |> Enum.into(%{}, fn {key, value} ->
-            {hex_to_int(key), hex_to_int(value)}
-          end)
-
-        Map.merge(address_map, %{
-          hex_to_bin(address) => %{
-            balance: hex_to_int(account["balance"]),
-            code: hex_to_bin(account["code"]),
-            nonce: hex_to_int(account["nonce"]),
-            storage: storage
-          }
-        })
-      end)
-
-    contract_result = %{
-      gas: 0,
-      sub_state: %EVM.SubState{},
-      output: <<>>
-    }
-
-    MockAccountRepo.new(
-      account_map,
-      contract_result
-    )
-  end
-
-  def block_header_info(test) do
-    genisis_block_header = %Block.Header{
-      number: 0,
-      mix_hash: 0
-    }
-
-    first_block_header = %Block.Header{
-      number: 1,
-      mix_hash: 0xC89EFDAA54C0F20C7ADF612882DF0950F5A951637E0307CDCB4C672F298B8BC6
-    }
-
-    second_block_header = %Block.Header{
-      number: 2,
-      mix_hash: 0xAD7C5BEF027816A800DA1736444FB58A807EF4C9603B7848673F7E3A68EB14A5
-    }
-
-    parent_block_header = %Block.Header{
-      number: hex_to_int(test["env"]["currentNumber"]) - 1,
-      mix_hash: 0x6CA54DA2C4784EA43FD88B3402DE07AE4BCED597CBB19F323B7595857A6720AE
-    }
-
-    last_block_header = %Block.Header{
-      number: hex_to_int(test["env"]["currentNumber"]),
-      timestamp: hex_to_int(test["env"]["currentTimestamp"]),
-      beneficiary: hex_to_bin(test["env"]["currentCoinbase"]),
-      mix_hash: 0,
-      parent_hash: hex_to_int(test["env"]["currentNumber"]) - 1,
-      gas_limit: hex_to_int(test["env"]["currentGasLimit"]),
-      difficulty: hex_to_int(test["env"]["currentDifficulty"])
-    }
-
-    block_map = %{
-      genisis_block_header.mix_hash => genisis_block_header,
-      first_block_header.mix_hash => first_block_header,
-      second_block_header.mix_hash => second_block_header,
-      parent_block_header.mix_hash => parent_block_header,
-      last_block_header.mix_hash => last_block_header
-    }
-
-    MockBlockHeaderInfo.new(
-      last_block_header,
-      block_map
-    )
   end
 
   def passing_tests(test_group_name) do

--- a/apps/evm/test/support/evm_test_runner.ex
+++ b/apps/evm/test/support/evm_test_runner.ex
@@ -1,0 +1,153 @@
+defmodule EVM.TestRunner do
+  import ExthCrypto.Math, only: [hex_to_bin: 1, hex_to_int: 1]
+
+  alias EVM.Mock.{MockAccountRepo, MockBlockHeaderInfo}
+  alias EVM.{ExecEnv, SubState, VM}
+
+  def run(json) do
+    exec_env = get_exec_env(json)
+    gas = hex_to_int(json["exec"]["gas"])
+    VM.run(gas, exec_env)
+  end
+
+  defp get_exec_env(json) do
+    %ExecEnv{
+      address: hex_to_bin(json["exec"]["address"]),
+      originator: hex_to_bin(json["exec"]["origin"]),
+      gas_price: hex_to_int(json["exec"]["gasPrice"]),
+      data: hex_to_bin(json["exec"]["data"]),
+      sender: hex_to_bin(json["exec"]["caller"]),
+      value_in_wei: hex_to_int(json["exec"]["value"]),
+      machine_code: hex_to_bin(json["exec"]["code"]),
+      account_repo: account_repo(json),
+      block_header_info: block_header_info(json)
+    }
+  end
+
+  defp block_header_info(json) do
+    if json["env"]["currentNumber"] == "0x00" do
+      single_block_header_info(json)
+    else
+      many_blocks_header_info(json)
+    end
+  end
+
+  defp single_block_header_info(json) do
+    build_block_header_info([
+      %Block.Header{
+        number: hex_to_int(json["env"]["currentNumber"]),
+        timestamp: hex_to_int(json["env"]["currentTimestamp"]),
+        beneficiary: hex_to_bin(json["env"]["currentCoinbase"]),
+        mix_hash: <<0::256>>,
+        parent_hash: <<0::256>>,
+        gas_limit: hex_to_int(json["env"]["currentGasLimit"]),
+        difficulty: hex_to_int(json["env"]["currentDifficulty"])
+      }
+    ])
+  end
+
+  defp many_blocks_header_info(json) do
+    genesis_block_header = %Block.Header{
+      number: 0,
+      timestamp: hex_to_int(json["env"]["currentTimestamp"]) - 1,
+      beneficiary: hex_to_bin(json["env"]["currentCoinbase"]),
+      mix_hash: 0x0000000000000000000000000000000000000000000000000000000000000000,
+      parent_hash: 0,
+      difficulty: hex_to_int(json["env"]["currentDifficulty"]) - 4
+    }
+
+    first_block_header = %Block.Header{
+      number: 1,
+      timestamp: hex_to_int(json["env"]["currentTimestamp"]) - 1,
+      beneficiary: hex_to_bin(json["env"]["currentCoinbase"]),
+      mix_hash: 0xC89EFDAA54C0F20C7ADF612882DF0950F5A951637E0307CDCB4C672F298B8BC6,
+      parent_hash: 0,
+      difficulty: hex_to_int(json["env"]["currentDifficulty"]) - 3
+    }
+
+    second_block_header = %Block.Header{
+      number: 2,
+      timestamp: hex_to_int(json["env"]["currentTimestamp"]) - 1,
+      beneficiary: hex_to_bin(json["env"]["currentCoinbase"]),
+      mix_hash: 0xAD7C5BEF027816A800DA1736444FB58A807EF4C9603B7848673F7E3A68EB14A5,
+      parent_hash: 0xC89EFDAA54C0F20C7ADF612882DF0950F5A951637E0307CDCB4C672F298B8BC6,
+      difficulty: hex_to_int(json["env"]["currentDifficulty"]) - 2
+    }
+
+    parent_block_header = %Block.Header{
+      number: hex_to_int(json["env"]["currentNumber"]) - 1,
+      timestamp: hex_to_int(json["env"]["currentTimestamp"]) - 1,
+      beneficiary: hex_to_bin(json["env"]["currentCoinbase"]),
+      mix_hash: 0x6CA54DA2C4784EA43FD88B3402DE07AE4BCED597CBB19F323B7595857A6720AE,
+      parent_hash: 0xAD7C5BEF027816A800DA1736444FB58A807EF4C9603B7848673F7E3A68EB14A5,
+      difficulty: hex_to_int(json["env"]["currentDifficulty"]) - 1
+    }
+
+    last_block_header = %Block.Header{
+      number: hex_to_int(json["env"]["currentNumber"]),
+      timestamp: hex_to_int(json["env"]["currentTimestamp"]),
+      beneficiary: hex_to_bin(json["env"]["currentCoinbase"]),
+      mix_hash: 0x0000000000000000000000000000000000000000000000000000000000000000,
+      parent_hash: 0x6CA54DA2C4784EA43FD88B3402DE07AE4BCED597CBB19F323B7595857A6720AE,
+      gas_limit: hex_to_int(json["env"]["currentGasLimit"]),
+      difficulty: hex_to_int(json["env"]["currentDifficulty"])
+    }
+
+    build_block_header_info([
+      last_block_header,
+      parent_block_header,
+      second_block_header,
+      first_block_header,
+      genesis_block_header
+    ])
+  end
+
+  defp build_block_header_info(headers = [most_recent_header | _]) do
+    block_map =
+      Enum.into(headers, %{}, fn header ->
+        {Block.Header.hash(header), header}
+      end)
+
+    MockBlockHeaderInfo.new(most_recent_header, block_map)
+  end
+
+  defp account_repo(json) do
+    account_map = %{
+      hex_to_bin(json["exec"]["caller"]) => %{
+        balance: 0,
+        code: <<>>,
+        nonce: 0,
+        storage: %{}
+      }
+    }
+
+    account_map =
+      Enum.reduce(json["pre"], account_map, fn {address, account}, address_map ->
+        storage =
+          account["storage"]
+          |> Enum.into(%{}, fn {key, value} ->
+            {hex_to_int(key), hex_to_int(value)}
+          end)
+
+        Map.merge(address_map, %{
+          hex_to_bin(address) => %{
+            balance: hex_to_int(account["balance"]),
+            code: hex_to_bin(account["code"]),
+            nonce: hex_to_int(account["nonce"]),
+            storage: storage
+          }
+        })
+      end)
+
+    contract_result = %{
+      gas: 0,
+      sub_state: %SubState{},
+      output: <<>>
+    }
+
+    MockAccountRepo.new(
+      account_map,
+      contract_result
+    )
+  end
+end


### PR DESCRIPTION
Why:

We would like to start profiling our evm code to look for areas where we
can improve performance. [Parity] has a [benchmark script] for
outputting how long each of the evm common_tests take to run

[Parity]: https://github.com/paritytech/parity-ethereum
[benchmark script]: https://github.com/paritytech/parity-ethereum/blob/f6dcca3ebb6341049b8fc4c890a463277c493bc4/scripts/evm_jsontests_bench.sh

This PR:

Extracts EvmTestRunner. This allows us to run the following type of code
for profiling:

```
% cd apps/evm
% MIX_ENV=test iex -S mix

iex(1)> test_json =
...(1)> File.read!("../../ethereum_common_tests/VMTests/vmPerformance/ackermann31.json") |>
...(1)> Jason.decode!() |>
...(1)> Map.get("ackermann31")
iex(2)> :fprof.apply(EvmTestRunner, :run, [test_json])
iex(3)> :fprof.profile
iex(4)> :fprof.analyse([callers: true, sort: :own, totals: true, details: true])
```