### PR TITLE
fix highest bit calculation for exp_mod builtin

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 21.1
-elixir 1.7.3-otp-21
+elixir 1.7.4-otp-21

--- a/apps/blockchain/mix.exs
+++ b/apps/blockchain/mix.exs
@@ -50,7 +50,6 @@ defmodule Blockchain.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:ethereumex, "~> 0.5.0"},
       {:evm, in_umbrella: true},
       {:ex_rlp, "~> 0.3.1"},
       {:exth_crypto, in_umbrella: true},

--- a/apps/blockchain/mix.exs
+++ b/apps/blockchain/mix.exs
@@ -50,6 +50,7 @@ defmodule Blockchain.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      {:ethereumex, "~> 0.5.0"},
       {:evm, in_umbrella: true},
       {:ex_rlp, "~> 0.3.1"},
       {:exth_crypto, in_umbrella: true},

--- a/apps/evm/lib/evm/builtin/mod_exp.ex
+++ b/apps/evm/lib/evm/builtin/mod_exp.ex
@@ -110,7 +110,7 @@ defmodule EVM.Builtin.ModExp do
     end
   end
 
-  @spec highest_bit(binary(), non_neg_interger()) :: non_neg_integer()
+  @spec highest_bit(binary(), non_neg_integer()) :: non_neg_integer()
   defp highest_bit(_, 0), do: 0
 
   defp highest_bit(binary_number, _) do

--- a/apps/evm/lib/evm/builtin/mod_exp.ex
+++ b/apps/evm/lib/evm/builtin/mod_exp.ex
@@ -110,9 +110,10 @@ defmodule EVM.Builtin.ModExp do
     end
   end
 
-  def highest_bit(_, 0), do: 0
+  @spec highest_bit(binary(), non_neg_interger()) :: non_neg_integer()
+  defp highest_bit(_, 0), do: 0
 
-  def highest_bit(binary_number, _) do
+  defp highest_bit(binary_number, _) do
     bit_list = for <<b::1 <- binary_number>>, do: b
     index = Enum.find_index(bit_list, fn x -> x != 0 end)
 

--- a/apps/evm/lib/evm/builtin/mod_exp.ex
+++ b/apps/evm/lib/evm/builtin/mod_exp.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Builtin.ModExp do
+  use Bitwise
   alias EVM.Memory
 
   @data_size_limit 24_577
@@ -106,13 +107,17 @@ defmodule EVM.Builtin.ModExp do
     end
   end
 
-  @spec highest_bit(non_neg_integer()) :: integer()
-  defp highest_bit(number) do
-    res =
-      number
-      |> :math.log2()
-      |> MathHelper.floor()
+  @spec highest_bit(non_neg_integer(), non_neg_integer(), boolean()) :: integer()
+  def highest_bit(number, res \\ 0, first_iter \\ true)
 
-    if res == 256, do: 255, else: res
+  def highest_bit(0, _, _), do: 0
+
+  def highest_bit(number, res, false) when number != 0, do: 254 - res
+
+  def highest_bit(number, res, _) do
+    res = res + 1
+    number = number >>> 1
+
+    highest_bit(number, res, false)
   end
 end

--- a/apps/evm/lib/evm/builtin/mod_exp.ex
+++ b/apps/evm/lib/evm/builtin/mod_exp.ex
@@ -1,5 +1,4 @@
 defmodule EVM.Builtin.ModExp do
-  use Bitwise
   alias EVM.Memory
 
   @data_size_limit 24_577

--- a/apps/evm/lib/evm/builtin/mod_exp.ex
+++ b/apps/evm/lib/evm/builtin/mod_exp.ex
@@ -93,7 +93,9 @@ defmodule EVM.Builtin.ModExp do
           integer()
   defp e_length_prime(e_length, e, _) when e == 0 and e_length <= 32, do: 0
 
-  defp e_length_prime(e_length, e, _) when e != 0 and e_length <= 32, do: highest_bit(e)
+  defp e_length_prime(e_length, e, _) when e_length <= 32 do
+    8 * (e_length - 32) + highest_bit(e)
+  end
 
   defp e_length_prime(e_length, _e, {b_length, data}) do
     <<_::binary-size(b_length), e_first_32_bytes_bin::binary-size(32), _::binary>> = data
@@ -108,11 +110,11 @@ defmodule EVM.Builtin.ModExp do
   end
 
   @spec highest_bit(non_neg_integer(), non_neg_integer(), boolean()) :: integer()
-  def highest_bit(number, res \\ 0, first_iter \\ true)
+  def highest_bit(number, res \\ 1, first_iter \\ true)
 
   def highest_bit(0, _, _), do: 0
 
-  def highest_bit(number, res, false) when number != 0, do: 254 - res
+  def highest_bit(number, res, false) when number != 0, do: 255 - res
 
   def highest_bit(number, res, _) do
     res = res + 1

--- a/apps/evm/test/evm/builtin/mod_exp_test.exs
+++ b/apps/evm/test/evm/builtin/mod_exp_test.exs
@@ -11,7 +11,7 @@ defmodule EVM.Builtin.ModExpTest do
     available_gas = 1_000_000
 
     exec_env = %EVM.ExecEnv{data: data, config: EVM.Configuration.Byzantium.new()}
-    {result_gas, _, _, output} = ModExp.exec(available_gas, exec_env) |> IO.inspect()
+    {result_gas, _, _, output} = ModExp.exec(available_gas, exec_env)
 
     cost = available_gas - result_gas
 

--- a/apps/evm/test/evm/builtin/mod_exp_test.exs
+++ b/apps/evm/test/evm/builtin/mod_exp_test.exs
@@ -3,6 +3,7 @@ defmodule EVM.Builtin.ModExpTest do
 
   alias EVM.Builtin.ModExp
 
+  # https://github.com/mana-ethereum/mana/issues/580
   test "calculates mod_exp (block #2_444_903, transaction #4 on ropsten)" do
     data =
       "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000203790e561ff7d7641aacb12e01f997c551b256e2da3072a0348643316b63886933fffffffffffffffffffffffffffffffffffffffffffffffffffffffbfffff0cfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"

--- a/apps/evm/test/evm/builtin/mod_exp_test.exs
+++ b/apps/evm/test/evm/builtin/mod_exp_test.exs
@@ -1,0 +1,24 @@
+defmodule EVM.Builtin.ModExpTest do
+  use ExUnit.Case, async: true
+
+  alias EVM.Builtin.ModExp
+
+  test "calculates mod_exp (block #2_444_903, transaction #4 on ropsten)" do
+    data =
+      "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000203790e561ff7d7641aacb12e01f997c551b256e2da3072a0348643316b63886933fffffffffffffffffffffffffffffffffffffffffffffffffffffffbfffff0cfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+      |> Base.decode16!(case: :lower)
+
+    available_gas = 1_000_000
+
+    exec_env = %EVM.ExecEnv{data: data, config: EVM.Configuration.Byzantium.new()}
+    {result_gas, _, _, output} = ModExp.exec(available_gas, exec_env) |> IO.inspect()
+
+    cost = available_gas - result_gas
+
+    assert cost == 12_953
+
+    assert output ==
+             <<166, 77, 176, 208, 195, 39, 151, 52, 51, 231, 30, 237, 237, 72, 125, 118, 61, 235,
+               159, 94, 12, 89, 197, 0, 244, 4, 188, 219, 122, 138, 212, 245>>
+  end
+end


### PR DESCRIPTION
wrong highest bit calculation caused wrong gas cost.
Because of that we were failing `ropsten` chain syncing on block #2_444_903

fixes https://github.com/mana-ethereum/mana/issues/580 