### PR TITLE
Fix Network Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,21 +14,21 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
 
@@ -37,41 +37,41 @@ jobs:
           no_output_timeout: 2400
 
       - save_cache:
-          key: v8-env-cache-{{ arch }}-{{ .Branch }}
+          key: v10-env-cache-{{ arch }}-{{ .Branch }}
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v8-env-cache-{{ .Branch }}
+          key: v10-env-cache-{{ .Branch }}
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v8-env-cache
+          key: v10-env-cache
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "deps"
       - save_cache:
-          key: v8-mix-cache-{{ .Branch }}
+          key: v10-mix-cache-{{ .Branch }}
           paths: "deps"
       - save_cache:
-          key: v8-mix-cache
+          key: v10-mix-cache
           paths: "deps"
 
       - save_cache:
-          key: v8-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: v10-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "_build"
       - save_cache:
-          key: v8-build-cache-{{ .Branch }}
+          key: v10-build-cache-{{ .Branch }}
           paths: "_build"
       - save_cache:
-          key: v8-build-cache
+          key: v10-build-cache
           paths: "_build"
 
       - run:
@@ -116,22 +116,56 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - run: mix test --exclude pending
+
+  network:
+    docker:
+      - image: circleci/elixir:1.7.4
+        environment:
+          MIX_ENV: test
+
+    working_directory: ~/app
+
+    steps:
+      - attach_workspace:
+           at: .
+
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+
+      - restore_cache:
+          keys:
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
+
+      - restore_cache:
+          keys:
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
+
+      - restore_cache:
+          keys:
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
+
+      - run: EXT_IP_ADDRESS=$(curl ifconfig.co) mix test --only network
 
   Frontier:
     docker:
@@ -150,20 +184,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include Frontier
 
@@ -184,20 +218,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include Homestead
 
@@ -218,20 +252,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include HomesteadToDaoAt5
 
@@ -252,20 +286,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include TangerineWhistle
 
@@ -286,20 +320,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include SpuriousDragon
 
@@ -320,20 +354,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include Byzantium
 
@@ -354,20 +388,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - run:
           command: mix cmd --app blockchain mix test --exclude test --include Constantinople
@@ -393,26 +427,26 @@ jobs:
 
       - restore_cache:
           keys:
-            - v8-build-cache-{{ .Branch }}
-            - v8-build-cache
+            - v10-build-cache-{{ .Branch }}
+            - v10-build-cache
 
       - restore_cache:
           keys:
-            - v8-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v8-mix-cache-{{ .Branch }}
-            - v8-mix-cache
+            - v10-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v10-mix-cache-{{ .Branch }}
+            - v10-mix-cache
 
       - restore_cache:
           keys:
-            - v8-env-cache-{{ arch }}-{{ .Branch }}
-            - v8-env-cache-{{ .Branch }}
-            - v8-env-cache
+            - v10-env-cache-{{ arch }}-{{ .Branch }}
+            - v10-env-cache-{{ .Branch }}
+            - v10-env-cache
 
       - restore_cache:
           keys:
-            - v8-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
-            - v8-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
-            - v8-plt-cache-{{ ".tool-versions" }}
+            - v10-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+            - v10-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+            - v10-plt-cache-{{ ".tool-versions" }}
 
       - run:
           name: Unpack PLT cache
@@ -432,17 +466,17 @@ jobs:
             cp ~/.mix/dialyxir*.plt plts/
 
       - save_cache:
-          key: v8-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+          key: v10-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
           paths:
             - plts
 
       - save_cache:
-          key: v8-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+          key: v10-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
           paths:
             - plts
 
       - save_cache:
-          key: v8-plt-cache-{{ ".tool-versions" }}
+          key: v10-plt-cache-{{ ".tool-versions" }}
           paths:
             - plts
 
@@ -537,3 +571,9 @@ workflows:
           requires: [build]
       - Constantinople:
           requires: [build]
+      - network:
+          requires: [build]
+          filters:
+            branches:
+              only:
+                - /.*network$/

--- a/apps/ex_wire/lib/ex_wire/config.ex
+++ b/apps/ex_wire/lib/ex_wire/config.ex
@@ -83,7 +83,13 @@ defmodule ExWire.Config do
 
   @spec public_ip(Keyword.t()) :: [integer()]
   def public_ip(given_params \\ []) do
-    get_env(given_params, :public_ip, @default_public_ip)
+    if conf_ip = System.get_env("EXT_IP_ADDRESS") do
+      conf_ip
+      |> String.split(".")
+      |> Enum.map(&String.to_integer/1)
+    else
+      get_env(given_params, :public_ip, @default_public_ip)
+    end
   end
 
   @spec node_id() :: ExWire.node_id()

--- a/apps/ex_wire/lib/ex_wire/handler.ex
+++ b/apps/ex_wire/lib/ex_wire/handler.ex
@@ -87,6 +87,7 @@ defmodule ExWire.Handler do
         :not_implemented
 
       mod when is_atom(mod) ->
+        Exth.trace(fn -> "Handling #{mod} message from #{inspect(params.remote_host.ip)}" end)
         apply(mod, :handle, [params, options])
     end
   end

--- a/apps/ex_wire/lib/ex_wire/kademlia/routing_table.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/routing_table.ex
@@ -229,24 +229,27 @@ defmodule ExWire.Kademlia.RoutingTable do
    - If a pong is expired, we do nothing.
   """
   @spec handle_pong(t(), Pong.t()) :: t()
-  def handle_pong(table = %__MODULE__{expected_pongs: pongs}, %Pong{
-        hash: hash,
-        timestamp: timestamp
-      }) do
+  def handle_pong(
+        table = %__MODULE__{expected_pongs: pongs},
+        %Pong{
+          hash: hash,
+          timestamp: timestamp
+        }
+      ) do
     {node, updated_pongs} = Map.pop(pongs, hash)
 
-    table = %{table | expected_pongs: updated_pongs}
+    table_without_expected_pong = %{table | expected_pongs: updated_pongs}
 
     if timestamp > Timestamp.now() do
       case node do
         {removal_candidate, _insertion_candidate, _} ->
-          refresh_node(table, removal_candidate)
+          refresh_node(table_without_expected_pong, removal_candidate)
 
         _ ->
-          table
+          table_without_expected_pong
       end
     else
-      table
+      table_without_expected_pong
     end
   end
 

--- a/apps/ex_wire/lib/ex_wire/node_discovery_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/node_discovery_supervisor.ex
@@ -1,7 +1,7 @@
 defmodule ExWire.NodeDiscoverySupervisor do
   @moduledoc """
   The Node Discovery Supervisor manages two processes. The first process is
-  Kademlia algorithm's routing table state: `ExWire.Kademlia.Server`, the
+  Kademlia algorithm's routing table state `ExWire.Kademlia.Server`, the
   second one is process that sends and receives all messages that are used
   for node discovery (ping, pong, ...).
   """
@@ -20,7 +20,6 @@ defmodule ExWire.NodeDiscoverySupervisor do
 
   def init(params) do
     kademlia_name = Keyword.get(params, :kademlia_process_name, KademliaState)
-
     {udp_module, udp_process_name} = ExWire.Config.udp_network_adapter(params)
     port = ExWire.Config.listen_port(params)
 

--- a/apps/ex_wire/lib/ex_wire/p2p/manager.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/manager.ex
@@ -10,6 +10,7 @@ defmodule ExWire.P2P.Manager do
   alias ExWire.Framing.Frame
   alias ExWire.{DEVp2p, Handshake, Packet, TCP}
   alias ExWire.DEVp2p.Session
+  alias ExWire.Handshake.Struct.AuthMsgV4
   alias ExWire.P2P.Connection
   alias ExWire.Struct.Peer
 
@@ -154,7 +155,7 @@ defmodule ExWire.P2P.Manager do
       {:active, :ok} ->
         conn
 
-      {:active, :activate} ->
+      {:inactive, :activate} ->
         new_session = attempt_session_activation(conn.session, packet)
 
         %{conn | session: new_session}
@@ -211,7 +212,7 @@ defmodule ExWire.P2P.Manager do
   defp handle_acknowledgement_received(data, conn = %{peer: peer}) do
     case Handshake.handle_ack(conn.handshake, data) do
       {:ok, handshake, secrets} ->
-        _ =
+        :ok =
           Logger.debug(fn -> "[Network] [#{peer}] Got ack from #{peer.host}, deriving secrets" end)
 
         Map.merge(conn, %{handshake: handshake, secrets: secrets})
@@ -232,7 +233,7 @@ defmodule ExWire.P2P.Manager do
       {:ok, handshake, secrets} ->
         peer = get_peer_info(handshake.auth_msg, socket)
 
-        _ = Logger.debug("[Network] Received auth. Sending ack.")
+        :ok = Logger.debug("[Network] Received auth. Sending ack.")
         :ok = send_unframed_data(handshake.encoded_ack_resp, socket, peer)
 
         Map.merge(conn, %{handshake: handshake, secrets: secrets, peer: peer})
@@ -296,7 +297,7 @@ defmodule ExWire.P2P.Manager do
     DEVp2p.hello_sent(session, hello)
   end
 
-  @spec get_peer_info(ExWire.Handshake.Struct.AuthMsgV4.t(), TCP.socket()) :: Peer.t()
+  @spec get_peer_info(AuthMsgV4.t(), TCP.socket()) :: Peer.t()
   defp get_peer_info(auth_msg, socket) do
     {host, port} = TCP.peer_info(socket)
     remote_id = Peer.hex_node_id(auth_msg.initiator_public_key)

--- a/apps/ex_wire/test/integration/dev_p2p_communication_test.exs
+++ b/apps/ex_wire/test/integration/dev_p2p_communication_test.exs
@@ -1,36 +1,40 @@
 defmodule ExWire.DEVp2pCommunicationTest do
   use ExUnit.Case, async: true
 
+  alias ExthCrypto.Key
   alias ExWire.{Config, Handshake}
   alias ExWire.Struct.Peer
 
   @moduletag network: true
 
   setup do
+    public_key = Config.public_key()
     private_key = Config.private_key()
-    Application.put_env(:ex_wire, :private_key, private_key)
+    host = get_host()
 
-    {:ok, %{private_key: private_key}}
+    {:ok, %{public_key: public_key, private_key: private_key, host: host}}
   end
 
-  test "nodes exchange encrypted handshake and DEVp2p protocol handshake", keys do
+  test "nodes exchange encrypted handshake and DEVp2p protocol handshake",
+       %{private_key: private_key, public_key: public_key, host: host} do
     port = 30_309
 
     {:ok, _recipient_pid} = start_recipient_process(port)
-    {:ok, initiator_pid} = start_initiator_process(port)
+    {:ok, initiator_pid} = start_initiator_process(host, port, public_key)
 
     trace_and_wait_for_messages(initiator_pid)
 
-    assert_received_ack_resp(initiator_pid, keys)
+    assert_received_ack_resp(initiator_pid, private_key)
     assert_encrypted_handshake_success(initiator_pid)
 
     assert_session_is_active(initiator_pid)
   end
 
-  defp assert_received_ack_resp(pid, %{private_key: private_key}) do
+  defp assert_received_ack_resp(pid, private_key) do
     assert_received({:trace, ^pid, :receive, {:tcp, _socket, ack_data}})
 
     {:ok, ack_resp, _, _} = Handshake.read_ack_resp(ack_data, private_key)
+
     assert %ExWire.Handshake.Struct.AckRespV4{} = ack_resp
   end
 
@@ -46,13 +50,16 @@ defmodule ExWire.DEVp2pCommunicationTest do
     assert ExWire.DEVp2p.session_active?(state.session)
   end
 
-  defp start_initiator_process(port) do
-    peer = build_peer_with_recipient_data(port)
-    ExWire.P2P.Server.start_link(:outbound, peer)
-  end
-
+  @spec start_recipient_process(integer()) :: GenServer.on_start()
   defp start_recipient_process(port) do
     ExWire.TCP.Listener.start_link(port: port, name: :listener)
+  end
+
+  @spec start_initiator_process(String.t(), integer(), Key.public_key()) :: GenServer.on_start()
+  defp start_initiator_process(host, port, public_key) do
+    peer = build_peer_with_recipient_data(host, port, public_key)
+
+    ExWire.P2P.Server.start_link(:outbound, peer, [])
   end
 
   defp trace_and_wait_for_messages(pid) do
@@ -61,16 +68,20 @@ defmodule ExWire.DEVp2pCommunicationTest do
     Process.sleep(500)
   end
 
-  def build_peer_with_recipient_data(port) do
-    node_id = Config.public_key() |> Peer.hex_node_id()
-    host = get_host()
+  @spec build_peer_with_recipient_data(String.t(), integer(), Key.public_key()) :: Peer.t()
+  defp build_peer_with_recipient_data(host, port, public_key) do
+    node_id = Peer.hex_node_id(public_key)
 
     Peer.new(host, port, node_id)
   end
 
+  @spec get_host() :: String.t()
   defp get_host do
     {:ok, hostname} = :inet.gethostname()
     {:ok, {_, _, _, _, _, [host_tuple]}} = :inet.gethostbyname(hostname)
-    host_tuple |> :inet.ntoa() |> to_string()
+
+    host_tuple
+    |> :inet.ntoa()
+    |> to_string()
   end
 end

--- a/apps/ex_wire/test/integration/remote_connection_test.exs
+++ b/apps/ex_wire/test/integration/remote_connection_test.exs
@@ -10,7 +10,7 @@ defmodule ExWire.RemoteConnectionTest do
 
   If you do set, set the `REMOTE_TEST_PEER` environment variable to the full `enode://...` address.
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   require Logger
 
@@ -20,7 +20,6 @@ defmodule ExWire.RemoteConnectionTest do
   @moduletag integration: true
   @moduletag network: true
 
-  @local_peer [127, 0, 0, 1]
   @local_peer_port 35_353
   @local_tcp_port 36_363
 
@@ -32,8 +31,7 @@ defmodule ExWire.RemoteConnectionTest do
     send(pid, {:incoming_packet, inbound_packet})
   end
 
-  @remote_test_peer System.get_env("REMOTE_TEST_PEER") ||
-                      ExWire.Config.chain().nodes |> List.last()
+  @remote_test_peer System.get_env("REMOTE_TEST_PEER") || List.first(ExWire.Config.chain().nodes)
 
   test "connect to remote peer for discovery" do
     %URI{
@@ -67,7 +65,7 @@ defmodule ExWire.RemoteConnectionTest do
     ping = %ExWire.Message.Ping{
       version: 1,
       from: %ExWire.Struct.Endpoint{
-        ip: @local_peer,
+        ip: ExWire.Config.public_ip(),
         tcp_port: @local_tcp_port,
         udp_port: @local_peer_port
       },
@@ -100,7 +98,7 @@ defmodule ExWire.RemoteConnectionTest do
 
         receive_neighbours()
     after
-      2_000 ->
+      60_000 ->
         raise "Expected pong, but did not receive before timeout."
     end
   end
@@ -111,9 +109,17 @@ defmodule ExWire.RemoteConnectionTest do
         # Check the message looks good
         message = decode_message(inbound_message)
 
-        assert Enum.count(message.nodes) > 5
+        case message do
+          %ExWire.Message.Neighbours{nodes: nodes} ->
+            assert Enum.count(nodes) > 5
+
+          _ ->
+            Exth.trace(fn -> "Expecting neighbors packet, got: #{inspect(message)}" end)
+
+            receive_neighbours()
+        end
     after
-      2_000 ->
+      60_000 ->
         raise "Expected neighbours, but did not receive before timeout."
     end
   end
@@ -133,9 +139,7 @@ defmodule ExWire.RemoteConnectionTest do
   test "connect to remote peer for handshake" do
     {:ok, peer} = ExWire.Struct.Peer.from_uri(@remote_test_peer)
 
-    {:ok, client_pid} = P2P.start_link(:outbound, peer)
-
-    P2P.subscribe(client_pid, {__MODULE__, :receive_packet, [self()]})
+    {:ok, client_pid} = P2P.start_link(:outbound, peer, [{__MODULE__, :receive_packet, [self()]}])
 
     receive_status(client_pid)
   end
@@ -159,12 +163,11 @@ defmodule ExWire.RemoteConnectionTest do
         receive_block_headers(client_pid)
 
       {:incoming_packet, packet} ->
-        if System.get_env("TRACE"),
-          do: _ = Logger.debug(fn -> "Expecting status packet, got: #{inspect(packet)}" end)
+        Exth.trace(fn -> "Expecting status packet, got: #{inspect(packet)}" end)
 
         receive_status(client_pid)
     after
-      10_000 ->
+      60_000 ->
         raise "Expected status, but did not receive before timeout."
     end
   end
@@ -179,13 +182,11 @@ defmodule ExWire.RemoteConnectionTest do
         receive_block_bodies(client_pid)
 
       {:incoming_packet, packet} ->
-        if System.get_env("TRACE"),
-          do:
-            _ = Logger.debug(fn -> "Expecting block headers packet, got: #{inspect(packet)}" end)
+        Exth.trace(fn -> "Expecting block headers packet, got: #{inspect(packet)}" end)
 
         receive_block_headers(client_pid)
     after
-      3_000 ->
+      60_000 ->
         raise "Expected block headers, but did not receive before timeout."
     end
   end
@@ -194,18 +195,17 @@ defmodule ExWire.RemoteConnectionTest do
     receive do
       {:incoming_packet, _packet = %Packet.BlockBodies{blocks: [block]}} ->
         # This is a genesis block
-        assert block.transactions_list == []
+        assert block.transactions == []
         assert block.ommers == []
 
         :ok = Logger.warn("Successfully received genesis block from peer.")
 
       {:incoming_packet, packet} ->
-        if System.get_env("TRACE"),
-          do: _ = Logger.debug(fn -> "Expecting block bodies packet, got: #{inspect(packet)}" end)
+        Exth.trace(fn -> "Expecting block bodies packet, got: #{inspect(packet)}" end)
 
         receive_block_bodies(client_pid)
     after
-      3_000 ->
+      60_000 ->
         raise "Expected block bodies, but did not receive before timeout."
     end
   end

--- a/apps/ex_wire/test/support/ex_wire/test_helper.ex
+++ b/apps/ex_wire/test/support/ex_wire/test_helper.ex
@@ -1,6 +1,6 @@
 defmodule ExWire.TestHelper do
   @moduledoc """
-    Helper methods shared across test files.
+  Helper methods shared across test files.
   """
 
   alias ExWire.Adapter.UDP


### PR DESCRIPTION
This patch fixes our network tests. The goal is to make sure the tests run well against local peers or the bootnodes from the chains. We also make sure the network tests can be run locally or in CircleCI. Though, we opt not to run the tests in CI (this can be changed by making a branch name that ends in "network"). The fixes include:

1. Allowing an external IP address to be specified to give a remote node a real peer id with an IP address that is not 127.0.0.1.
2. Fix a discovery test that initiates find neighbours and checks that we've sent pings. We opt to ignore the pong responses as a simple way of tracking which nodes we've contracted so far.
3. We don't run remote connection tests asynchronously, since it meant we sent multiple connection attempts simultaneously to the same peer.
4. We increase timeouts, since real nodes take some time to respond.