### PR TITLE
Queue Extra Data from EIP-8 Frame

### DIFF
--- a/apps/ex_wire/lib/ex_wire/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake.ex
@@ -156,15 +156,15 @@ defmodule ExWire.Handshake do
   # TODO: Add examples
   """
   @spec handle_ack(t(), binary()) ::
-          {:ok, t(), Secrets.t()}
+          {:ok, t(), Secrets.t(), binary()}
           | {:invalid, :invalid_ECIES_encoded_message | :invalid_message_tag}
   def handle_ack(handshake = %Handshake{}, ack_data) do
     case read_ack_resp(ack_data, ExWire.Config.private_key()) do
-      {:ok, ack_resp, _ack_resp_bin, _frame_rest} ->
-        updated_handshake = add_ack_data(handshake, ack_resp, ack_data)
+      {:ok, ack_resp, ack_resp_bin, frame_rest} ->
+        updated_handshake = add_ack_data(handshake, ack_resp, ack_resp_bin)
         secrets = ExWire.Framing.Secrets.derive_secrets(updated_handshake)
 
-        {:ok, updated_handshake, secrets}
+        {:ok, updated_handshake, secrets, frame_rest}
 
       {:error, reason} ->
         {:invalid, reason}

--- a/apps/ex_wire/lib/ex_wire/p2p/manager.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/manager.ex
@@ -211,11 +211,11 @@ defmodule ExWire.P2P.Manager do
   @spec handle_acknowledgement_received(binary(), Connection.t()) :: Connection.t()
   defp handle_acknowledgement_received(data, conn = %{peer: peer}) do
     case Handshake.handle_ack(conn.handshake, data) do
-      {:ok, handshake, secrets} ->
+      {:ok, handshake, secrets, queued_data} ->
         :ok =
           Logger.debug(fn -> "[Network] [#{peer}] Got ack from #{peer.host}, deriving secrets" end)
 
-        Map.merge(conn, %{handshake: handshake, secrets: secrets})
+        Map.merge(conn, %{handshake: handshake, secrets: secrets, queued_data: queued_data})
 
       {:invalid, reason} ->
         :ok =

--- a/apps/ex_wire/lib/ex_wire/p2p/server.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/server.ex
@@ -110,7 +110,7 @@ defmodule ExWire.P2P.Server do
   def init(opts = %{is_outbound: true, peer: peer}) do
     {:ok, socket} = TCP.connect(peer.host, peer.port)
 
-    _ =
+    :ok =
       Logger.debug(fn ->
         "[Network] [#{peer}] Established outbound connection with #{peer.host}."
       end)

--- a/apps/ex_wire/test/ex_wire/handshake_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake_test.exs
@@ -93,8 +93,8 @@ defmodule HandshakeTest do
 
       set_environment(my_static_private_key)
 
-      {:ok, my_updated_handshake, my_secrets} =
-        Handshake.handle_ack(my_handshake, her_handshake.encoded_ack_resp)
+      assert {:ok, my_updated_handshake, my_secrets, <<>>} =
+               Handshake.handle_ack(my_handshake, her_handshake.encoded_ack_resp)
 
       assert my_updated_handshake.ack_resp == her_handshake.ack_resp
       assert %ExWire.Framing.Secrets{} = my_secrets


### PR DESCRIPTION
When we receive an EIP-8 frame, the packet specifies a size for the EIP-8 header data, but may contain more data that is unrelated to the EIP-8 data. We previously included the extra packet data as the pre-warm for the ingress header, that caused packets like this to break our handshake mechanism (or more correctly, break the next inbound packet). We now correctly set the ingress mac and queue the rest of the data as we await the next packet. This fixes an issue where Parity connections would often fail.