### PR TITLE
Start to be smarter about bootnodes and syncing

### DIFF
--- a/apps/ex_wire/lib/ex_wire/config.ex
+++ b/apps/ex_wire/lib/ex_wire/config.ex
@@ -135,12 +135,17 @@ defmodule ExWire.Config do
 
   @spec bootnodes(Keyword.t()) :: [String.t()]
   def bootnodes(given_params \\ []) do
-    case get_env(given_params, :bootnodes) do
-      nodes when is_list(nodes) ->
-        nodes
+    if conf_ip = System.get_env("BOOTNODES") do
+      conf_ip
+      |> String.split(",")
+    else
+      case get_env(given_params, :bootnodes) do
+        nodes when is_list(nodes) ->
+          nodes
 
-      :from_chain ->
-        chain().nodes
+        :from_chain ->
+          chain().nodes
+      end
     end
   end
 

--- a/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
@@ -27,7 +27,7 @@ defmodule ExWire.PeerSupervisor do
 
     spec = {ExWire.P2P.Server, {:outbound, peer, [{:server, ExWire.Sync}]}}
 
-    DynamicSupervisor.start_child(@name, spec)
+    {:ok, _pid} = DynamicSupervisor.start_child(@name, spec)
   end
 
   @doc """
@@ -46,6 +46,13 @@ defmodule ExWire.PeerSupervisor do
       end
 
     if Enum.member?(results, :ok), do: :ok, else: :unsent
+  end
+
+  @spec connected_peer_count() :: non_neg_integer()
+  def connected_peer_count() do
+    @name
+    |> DynamicSupervisor.which_children()
+    |> Enum.count()
   end
 
   @impl true


### PR DESCRIPTION
This patch starts getting our syncing code smarter about what peers it's connected to and why. We allow a user to specify bootnodes from the command line, and we check to see if we're connected to any nodes before we request new blocks. If we haven't yet connected, we'll wait and retry. This logic will grow as we start to run nodes that are consistently connected to 10-25 peers.