### PR TITLE
Support IPv6 Addresses

### DIFF
--- a/apps/ex_wire/lib/ex_wire/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp.ex
@@ -35,9 +35,10 @@ defmodule ExWire.TCP do
     :gen_tcp.shutdown(socket, :read_write)
   end
 
-  @spec connect(binary(), char()) :: {:ok, socket()} | {:error, atom()}
+  @spec connect(:inet.socket_address() | :inet.hostname(), char()) ::
+          {:ok, socket()} | {:error, atom()}
   def connect(host, port_number) do
-    :gen_tcp.connect(String.to_charlist(host), port_number, [:binary])
+    :gen_tcp.connect(host, port_number, [:binary])
   end
 
   @spec peer_info(socket()) :: {binary(), integer()}

--- a/apps/ex_wire/lib/ex_wire/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp.ex
@@ -41,10 +41,9 @@ defmodule ExWire.TCP do
     :gen_tcp.connect(host, port_number, [:binary])
   end
 
-  @spec peer_info(socket()) :: {binary(), integer()}
+  @spec peer_info(socket()) :: {:inet.ip_address(), integer()}
   def peer_info(socket) do
-    {:ok, {host_tuple, port}} = :inet.peername(socket)
-    host = host_tuple |> :inet.ntoa() |> to_string()
+    {:ok, {host, port}} = :inet.peername(socket)
 
     {host, port}
   end


### PR DESCRIPTION
This patch allows us to support peers with IPv6 addresses. Erlang has good tools on parsing addresses, though not as much as determining if this might be an address, so when we parse a peer node, we first try it as an IP address, and if that fails, we return it as a charlist (domain name). This allows us to connect to peers with IPv6 addresses, which, for instance, is the enode address when you run `geth --nat none`.