### PR TITLE
Connect Discovery to Peer-to-Peer

### DIFF
--- a/apps/ex_wire/README.md
+++ b/apps/ex_wire/README.md
@@ -6,7 +6,7 @@ Elixir Client for RLPx, DevP2P and Eth Wire Protocol.
 
 For the time being, this can be used to sync the block chain from a given network (currently defaulted to Ropsten).
 
-You can run `iex -S mix` and you should see:
+You can run `EXT_IP_ADDRESS=$(curl ifconfig.co) iex -S mix` and you should see:
 
 ```
 12:59:23.818 [debug] [Network] [6ce059...1acd9d] Established outbound connection with 13.84.180.240, sending auth.
@@ -33,6 +33,15 @@ You can run `iex -S mix` and you should see:
 
 12:59:24.595 [debug] [Block Queue] Verified block and added to new block tree
 ```
+
+To run against just a local node, run:
+
+Run geth, e.g.:
+`geth --testnet --nat none`
+
+Get the enode address and then run ExWire:
+
+`BOOTNODES=enode://... DISCOVERY=false mix run --no-halt`
 
 In the future, we will continue to grow and built out a proper syncing ability.
 It's likely the proper interface (with CLI tools) will not be this module directly, but instead a general CLI which calls into this module.

--- a/apps/ex_wire/config/dev.exs
+++ b/apps/ex_wire/config/dev.exs
@@ -2,11 +2,11 @@ use Mix.Config
 
 config :ex_wire,
   network_adapter: {ExWire.Adapter.UDP, NetworkClient},
-  sync: false,
+  sync: true,
+  discovery: true,
   private_key:
     <<10, 122, 189, 137, 166, 190, 127, 238, 229, 16, 211, 182, 104, 78, 138, 37, 146, 116, 90,
       68, 76, 86, 168, 24, 200, 155, 0, 99, 58, 226, 211, 30>>,
-  discovery: true,
   node_discovery: [
     network_adapter: {ExWire.Adapter.UDP, NetworkClient},
     kademlia_process_name: KademliaState,

--- a/apps/ex_wire/lib/ex_wire/config.ex
+++ b/apps/ex_wire/lib/ex_wire/config.ex
@@ -78,7 +78,11 @@ defmodule ExWire.Config do
 
   @spec perform_discovery?(Keyword.t()) :: boolean()
   def perform_discovery?(given_params \\ []) do
-    get_env(given_params, :discovery, false)
+    if discovery_str = System.get_env("DISCOVERY") do
+      coerce_boolean(discovery_str)
+    else
+      get_env(given_params, :discovery, false)
+    end
   end
 
   @spec public_ip(Keyword.t()) :: [integer()]
@@ -203,4 +207,12 @@ defmodule ExWire.Config do
 
     value
   end
+
+  @spec coerce_boolean(String.t()) :: boolean()
+  defp coerce_boolean("TRUE"), do: true
+  defp coerce_boolean("true"), do: true
+  defp coerce_boolean("T"), do: true
+  defp coerce_boolean("t"), do: true
+  defp coerce_boolean("1"), do: true
+  defp coerce_boolean(_), do: false
 end

--- a/apps/ex_wire/lib/ex_wire/kademlia/discovery.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/discovery.ex
@@ -16,13 +16,14 @@ defmodule ExWire.Kademlia.Discovery do
 
     this_round_nodes = RoutingTable.discovery_nodes(table)
 
-    if Config.perform_sync?() do
-      for node <- this_round_nodes do
-        node
-        |> Peer.from_node()
-        |> PeerSupervisor.new_peer()
+    _ =
+      if Config.perform_sync?() do
+        for node <- this_round_nodes do
+          node
+          |> Peer.from_node()
+          |> PeerSupervisor.new_peer()
+        end
       end
-    end
 
     Enum.each(this_round_nodes, fn node ->
       find_neighbours(table, node)

--- a/apps/ex_wire/lib/ex_wire/kademlia/discovery.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/discovery.ex
@@ -2,9 +2,10 @@ defmodule ExWire.Kademlia.Discovery do
   @moduledoc """
   Module that handles node discovery logic.
   """
+  alias ExWire.{Config, Network, PeerSupervisor}
   alias ExWire.Kademlia.{Node, RoutingTable}
   alias ExWire.Message.FindNeighbours
-  alias ExWire.Network
+  alias ExWire.Struct.Peer
 
   @doc """
   Starts discovery round.
@@ -14,6 +15,14 @@ defmodule ExWire.Kademlia.Discovery do
     table = add_bootnodes(table, bootnodes)
 
     this_round_nodes = RoutingTable.discovery_nodes(table)
+
+    if Config.perform_sync?() do
+      for node <- this_round_nodes do
+        node
+        |> Peer.from_node()
+        |> PeerSupervisor.new_peer()
+      end
+    end
 
     Enum.each(this_round_nodes, fn node ->
       find_neighbours(table, node)

--- a/apps/ex_wire/lib/ex_wire/kademlia/node.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/node.ex
@@ -50,7 +50,7 @@ defmodule ExWire.Kademlia.Node do
       %ExWire.Kademlia.Node{
         endpoint: %ExWire.Struct.Endpoint{
           ip: [52, 169, 14, 227],
-          tcp_port: nil,
+          tcp_port: 30303,
           udp_port: 30303
         },
         key: <<202, 107, 222, 100, 235, 37, 246, 148, 81, 241, 131, 186, 231, 136, 53,
@@ -91,7 +91,8 @@ defmodule ExWire.Kademlia.Node do
 
     endpoint = %Endpoint{
       ip: remote_ip,
-      udp_port: remote_peer_port
+      udp_port: remote_peer_port,
+      tcp_port: remote_peer_port
     }
 
     public_key = Crypto.hex_to_bin(remote_id)

--- a/apps/ex_wire/lib/ex_wire/p2p/manager.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/manager.ex
@@ -113,7 +113,7 @@ defmodule ExWire.P2P.Manager do
             {:ok, packet_mod, packet} ->
               :ok =
                 Logger.debug(fn ->
-                  "[Network] [#{peer}] Got packet `#{inspect(packet_mod)}` from #{peer.host}"
+                  "[Network] [#{peer}] Got packet `#{inspect(packet_mod)}` from #{peer.host_name}"
                 end)
 
               _ = notify_subscribers(packet, conn_after_unframe)
@@ -124,7 +124,7 @@ defmodule ExWire.P2P.Manager do
             :unknown_packet_type ->
               :ok =
                 Logger.error(fn ->
-                  "[Network] [#{peer}] Got unknown packet `#{packet_type}` from #{peer.host}"
+                  "[Network] [#{peer}] Got unknown packet `#{packet_type}` from #{peer.host_name}"
                 end)
 
               conn_after_unframe
@@ -139,7 +139,7 @@ defmodule ExWire.P2P.Manager do
       {:error, reason} ->
         _ =
           Logger.error(
-            "[Network] [#{peer}] Failed to read incoming packet from #{peer.host} `#{reason}`)"
+            "[Network] [#{peer}] Failed to read incoming packet from #{peer.host_name} `#{reason}`)"
           )
 
         %{conn | last_error: reason}
@@ -213,7 +213,9 @@ defmodule ExWire.P2P.Manager do
     case Handshake.handle_ack(conn.handshake, data) do
       {:ok, handshake, secrets, queued_data} ->
         :ok =
-          Logger.debug(fn -> "[Network] [#{peer}] Got ack from #{peer.host}, deriving secrets" end)
+          Logger.debug(fn ->
+            "[Network] [#{peer}] Got ack from #{peer.host_name}, deriving secrets"
+          end)
 
         Map.merge(conn, %{handshake: handshake, secrets: secrets, queued_data: queued_data})
 
@@ -260,7 +262,7 @@ defmodule ExWire.P2P.Manager do
 
     :ok =
       Logger.debug(fn ->
-        "[Network] [#{peer}] Sending packet #{inspect(packet_mod)} to #{peer.host} (##{
+        "[Network] [#{peer}] Sending packet #{inspect(packet_mod)} to #{peer.host_name} (##{
           conn.sent_message_count + 1
         })"
       end)
@@ -282,7 +284,7 @@ defmodule ExWire.P2P.Manager do
     _ =
       Logger.debug(fn ->
         "[Network] [#{peer}] Sending raw data message of length #{byte_size(data)} byte(s) to #{
-          peer.host
+          peer.host_name
         }"
       end)
 

--- a/apps/ex_wire/lib/ex_wire/p2p/server.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/server.ex
@@ -20,6 +20,8 @@ defmodule ExWire.P2P.Server do
   alias ExWire.P2P.{Connection, Manager}
   alias ExWire.Struct.Peer
 
+  @type state :: Connection.t()
+
   @type subscription() :: {module(), atom(), list()} | {:server, pid()}
 
   @doc """
@@ -104,23 +106,21 @@ defmodule ExWire.P2P.Server do
   end
 
   @doc """
+  Client function to get peer associated with this gen server
+  """
+  @spec get_peer(pid()) :: Peer.t()
+  def get_peer(pid) do
+    GenServer.call(pid, :get_peer)
+  end
+
+  @doc """
   Initialize by opening up a `gen_tcp` connection to given host and port.
   """
-  @spec init(map()) :: {:ok, Connection.t()}
+  @spec init(map()) :: {:ok, state()}
   def init(opts = %{is_outbound: true, peer: peer}) do
-    {:ok, socket} = TCP.connect(peer.host, peer.port)
+    Process.send_after(self(), {:connect, opts}, 0)
 
-    :ok =
-      Logger.debug(fn ->
-        "[Network] [#{peer}] Established outbound connection with #{peer.host}."
-      end)
-
-    state =
-      socket
-      |> Manager.new_outbound_connection(peer)
-      |> Map.put(:subscribers, Map.get(opts, :subscribers, []))
-
-    {:ok, state}
+    {:ok, %Connection{peer: peer}}
   end
 
   def init(opts = %{is_outbound: false, socket: socket}) do
@@ -132,16 +132,30 @@ defmodule ExWire.P2P.Server do
     {:ok, state}
   end
 
-  @doc """
-  Allows a client to subscribe to incoming packets. Subscribers must be in the form
-  of `{module, function, args}`, in which case we'll call `module.function(packet, ...args)`,
-  or `{:server, server_pid}` for a GenServer, in which case we'll send a message
-  `{:packet, packet, peer}`.
-  """
+  def handle_call(:get_peer, _from, state = %{peer: peer}) do
+    {:reply, peer, state}
+  end
+
   def handle_call({:subscribe, subscription}, _from, state) do
     {:ok, new_state} = handle_subscribe(subscription, state)
 
     {:reply, :ok, new_state}
+  end
+
+  def handle_info({:connect, opts}, %{peer: peer}) do
+    {:ok, socket} = TCP.connect(peer.host, peer.port)
+
+    :ok =
+      Logger.debug(fn ->
+        "[Network] [#{peer}] Established outbound connection with #{peer.host}."
+      end)
+
+    new_conn =
+      socket
+      |> Manager.new_outbound_connection(peer)
+      |> Map.put(:subscribers, Map.get(opts, :subscribers, []))
+
+    {:noreply, new_conn}
   end
 
   @doc """
@@ -180,7 +194,11 @@ defmodule ExWire.P2P.Server do
     {:noreply, new_state}
   end
 
-  @spec handle_subscribe(subscription(), Connection.t()) :: {:ok, Connection.t()}
+  # Allows a client to subscribe to incoming packets. Subscribers must be in the form
+  # of `{module, function, args}`, in which case we'll call `module.function(packet, ...args)`,
+  # or `{:server, server_pid}` for a GenServer, in which case we'll send a message
+  # `{:packet, packet, peer}`.
+  @spec handle_subscribe(subscription(), state()) :: {:ok, state()}
   defp handle_subscribe(mfa = {_module, _function, _args}, state) do
     new_state = Map.update(state, :subscribers, [mfa], fn subscribers -> [mfa | subscribers] end)
 
@@ -194,14 +212,14 @@ defmodule ExWire.P2P.Server do
     {:ok, new_state}
   end
 
-  @spec handle_socket_message(binary(), Connection.t()) :: {:ok, Connection.t()}
+  @spec handle_socket_message(binary(), state()) :: {:ok, state()}
   defp handle_socket_message(data, state) do
     new_state = Manager.handle_message(state, data)
 
     {:ok, new_state}
   end
 
-  @spec handle_socket_close(Connection.t()) :: {:ok, Connection.t()}
+  @spec handle_socket_close(state()) :: {:ok, state()}
   defp handle_socket_close(state) do
     peer = Map.get(state, :peer, :unknown)
 
@@ -212,14 +230,14 @@ defmodule ExWire.P2P.Server do
     {:ok, state}
   end
 
-  @spec handle_send(Packet.packet(), Connection.t()) :: {:ok, Connection.t()}
+  @spec handle_send(Packet.packet(), state()) :: {:ok, state()}
   defp handle_send(packet, state) do
     new_state = Manager.send_packet(state, packet)
 
     {:ok, new_state}
   end
 
-  @spec handle_disconnection(TCP.socket(), Connection.t()) :: {:ok, Connection.t()}
+  @spec handle_disconnection(TCP.socket(), state()) :: {:ok, state()}
   defp handle_disconnection(socket, state) do
     :ok = TCP.shutdown(socket)
     new_state = Map.delete(state, :socket)

--- a/apps/ex_wire/lib/ex_wire/p2p/server.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/server.ex
@@ -147,7 +147,7 @@ defmodule ExWire.P2P.Server do
 
     :ok =
       Logger.debug(fn ->
-        "[Network] [#{peer}] Established outbound connection with #{peer.host}."
+        "[Network] [#{peer}] Established outbound connection with #{peer.host_name}."
       end)
 
     new_conn =

--- a/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
@@ -8,8 +8,8 @@ defmodule ExWire.PeerSupervisor do
 
   require Logger
 
-  alias ExWire.Packet
   alias ExWire.P2P.Server
+  alias ExWire.Packet
   alias ExWire.Struct.Peer
 
   @type node_selector :: :all | :random | :last

--- a/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
@@ -34,15 +34,17 @@ defmodule ExWire.PeerSupervisor do
     peer_count = connected_peer_count()
 
     if peer_count < @max_peers do
-      Logger.debug(fn ->
-        "[PeerSup] Connecting to peer #{peer} (#{peer_count} of #{@max_peers} peers)"
-      end)
+      :ok =
+        Logger.debug(fn ->
+          "[PeerSup] Connecting to peer #{peer} (#{peer_count} of #{@max_peers} peers)"
+        end)
 
       spec = {Server, {:outbound, peer, [{:server, ExWire.Sync}]}}
 
       {:ok, _pid} = DynamicSupervisor.start_child(@name, spec)
     else
-      Logger.debug(fn -> "[PeerSup] Not connecting due to max peers (#{@max_peers}) reached" end)
+      :ok =
+        Logger.debug(fn -> "[PeerSup] Not connecting due to max peers (#{@max_peers}) reached" end)
     end
   end
 
@@ -108,13 +110,14 @@ defmodule ExWire.PeerSupervisor do
 
   @impl true
   def init(peer_enode_urls) do
-    Task.start_link(fn ->
-      for peer_enode_url <- peer_enode_urls do
-        {:ok, peer} = ExWire.Struct.Peer.from_uri(peer_enode_url)
+    _ =
+      Task.start_link(fn ->
+        for peer_enode_url <- peer_enode_urls do
+          {:ok, peer} = ExWire.Struct.Peer.from_uri(peer_enode_url)
 
-        new_peer(peer)
-      end
-    end)
+          new_peer(peer)
+        end
+      end)
 
     {:ok, _} = DynamicSupervisor.init(strategy: :one_for_one)
   end

--- a/apps/ex_wire/lib/ex_wire/struct/peer.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/peer.ex
@@ -12,6 +12,7 @@ defmodule ExWire.Struct.Peer do
 
   alias ExthCrypto.Key
   alias ExWire.Crypto
+  alias ExWire.Kademlia.Node
 
   @type t :: %__MODULE__{
           host: :inet.socket_address() | :inet.hostname(),
@@ -136,6 +137,46 @@ defmodule ExWire.Struct.Peer do
       {:error, _} ->
         hostname_chars
     end
+  end
+
+  @doc """
+  Creates a node struct from a Kademlia node.
+
+  ## Examples
+
+      iex> %ExWire.Kademlia.Node{
+      ...>  endpoint: %ExWire.Struct.Endpoint{
+      ...>    ip: [52, 169, 14, 227],
+      ...>    tcp_port: nil,
+      ...>    udp_port: 30303
+      ...>  },
+      ...>  key: <<202, 107, 222, 100, 235, 37, 246, 148, 81, 241, 131, 186, 231, 136, 53,
+      ...>    244, 150, 181, 223, 94, 85, 8, 248, 17, 242, 130, 233, 242, 131, 19, 153,
+      ...>    173>>,
+      ...>  public_key: <<32, 201, 173, 151, 192, 129, 214, 51, 151, 215, 182, 133, 164,
+      ...>    18, 34, 122, 64, 226, 60, 139, 220, 102, 136, 198, 243, 126, 151, 207, 188,
+      ...>    34, 210, 180, 209, 219, 21, 16, 216, 246, 30, 106, 136, 102, 173, 127, 14,
+      ...>    23, 192, 43, 20, 24, 45, 55, 234, 124, 60, 139, 156, 38, 131, 174, 182, 183,
+      ...>    51, 161>>
+      ...> } |> ExWire.Struct.Peer.from_node()
+      %ExWire.Struct.Peer{
+        host: {52, 169, 14, 227},
+        ident: "20c9ad...b733a1",
+        port: nil,
+        remote_id: <<32, 201, 173, 151, 192, 129, 214, 51, 151, 215, 182, 133, 164,
+          18, 34, 122, 64, 226, 60, 139, 220, 102, 136, 198, 243, 126, 151, 207, 188,
+          34, 210, 180, 209, 219, 21, 16, 216, 246, 30, 106, 136, 102, 173, 127, 14,
+          23, 192, 43, 20, 24, 45, 55, 234, 124, 60, 139, 156, 38, 131, 174, 182, 183,
+          51, 161>>
+      }
+  """
+  @spec from_node(Node.t()) :: t()
+  def from_node(kademlia_node) do
+    __MODULE__.new(
+      List.to_tuple(kademlia_node.endpoint.ip),
+      kademlia_node.endpoint.tcp_port,
+      Crypto.bin_to_hex(kademlia_node.public_key)
+    )
   end
 end
 

--- a/apps/ex_wire/lib/ex_wire/struct/peer.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/peer.ex
@@ -173,7 +173,7 @@ defmodule ExWire.Struct.Peer do
   @spec from_node(Node.t()) :: t()
   def from_node(kademlia_node) do
     __MODULE__.new(
-      List.to_tuple(kademlia_node.endpoint.ip),
+      Enum.join(List.to_tuple(kademlia_node.endpoint.ip), "."),
       kademlia_node.endpoint.tcp_port,
       Crypto.bin_to_hex(kademlia_node.public_key)
     )

--- a/apps/ex_wire/lib/ex_wire/struct/peer.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/peer.ex
@@ -5,6 +5,7 @@ defmodule ExWire.Struct.Peer do
 
   defstruct [
     :host,
+    :host_name,
     :port,
     :remote_id,
     :ident
@@ -16,6 +17,7 @@ defmodule ExWire.Struct.Peer do
 
   @type t :: %__MODULE__{
           host: :inet.socket_address() | :inet.hostname(),
+          host_name: String.t(),
           port: :inet.port_number(),
           remote_id: Key.public_key(),
           ident: String.t()
@@ -29,6 +31,7 @@ defmodule ExWire.Struct.Peer do
       iex> ExWire.Struct.Peer.new({13, 84, 180, 240}, 30303, "6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d")
       %ExWire.Struct.Peer{
         host: {13, 84, 180, 240},
+        host_name: "13.84.180.240",
         port: 30303,
         remote_id: <<108, 224, 89, 48, 199, 42, 188, 99, 44, 88, 226, 228, 50, 79, 124, 126, 164, 120, 206, 192, 237, 79, 162, 82, 137, 130, 207, 52, 72, 48, 148, 233, 203, 201, 33, 110, 122, 163, 73, 105, 18, 66, 87, 109, 85, 42, 42, 86, 170, 234, 228, 38, 197, 48, 61, 237, 103, 124, 228, 85, 186, 26, 205, 157>>,
         ident: "6ce059...1acd9d"
@@ -44,6 +47,7 @@ defmodule ExWire.Struct.Peer do
 
     %__MODULE__{
       host: host,
+      host_name: inet_host_to_uri_host(host),
       port: port,
       remote_id: remote_id,
       ident: ident
@@ -73,6 +77,7 @@ defmodule ExWire.Struct.Peer do
       iex> ExWire.Struct.Peer.from_uri("enode://6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d@13.84.180.240:30303")
       {:ok, %ExWire.Struct.Peer{
         host: {13, 84, 180, 240},
+        host_name: "13.84.180.240",
         port: 30303,
         remote_id: <<108, 224, 89, 48, 199, 42, 188, 99, 44, 88, 226, 228, 50, 79, 124, 126, 164, 120, 206, 192, 237, 79, 162, 82, 137, 130, 207, 52, 72, 48, 148, 233, 203, 201, 33, 110, 122, 163, 73, 105, 18, 66, 87, 109, 85, 42, 42, 86, 170, 234, 228, 38, 197, 48, 61, 237, 103, 124, 228, 85, 186, 26, 205, 157>>,
         ident: "6ce059...1acd9d"
@@ -81,6 +86,7 @@ defmodule ExWire.Struct.Peer do
       iex> ExWire.Struct.Peer.from_uri("enode://6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d@[::]:30303")
       {:ok, %ExWire.Struct.Peer{
         host: {0, 0, 0, 0, 0, 0, 0, 0},
+        host_name: "0::0::0::0::0::0::0::0",
         port: 30303,
         remote_id: <<108, 224, 89, 48, 199, 42, 188, 99, 44, 88, 226, 228, 50, 79, 124, 126, 164, 120, 206, 192, 237, 79, 162, 82, 137, 130, 207, 52, 72, 48, 148, 233, 203, 201, 33, 110, 122, 163, 73, 105, 18, 66, 87, 109, 85, 42, 42, 86, 170, 234, 228, 38, 197, 48, 61, 237, 103, 124, 228, 85, 186, 26, 205, 157>>,
         ident: "6ce059...1acd9d"
@@ -89,6 +95,7 @@ defmodule ExWire.Struct.Peer do
       iex> ExWire.Struct.Peer.from_uri("enode://6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d@google.com:30303")
       {:ok, %ExWire.Struct.Peer{
         host: 'google.com',
+        host_name: "google.com",
         port: 30303,
         remote_id: <<108, 224, 89, 48, 199, 42, 188, 99, 44, 88, 226, 228, 50, 79, 124, 126, 164, 120, 206, 192, 237, 79, 162, 82, 137, 130, 207, 52, 72, 48, 148, 233, 203, 201, 33, 110, 122, 163, 73, 105, 18, 66, 87, 109, 85, 42, 42, 86, 170, 234, 228, 38, 197, 48, 61, 237, 103, 124, 228, 85, 186, 26, 205, 157>>,
         ident: "6ce059...1acd9d"
@@ -140,6 +147,38 @@ defmodule ExWire.Struct.Peer do
   end
 
   @doc """
+  Takes a given erlang-style host and converts it to a normal
+  host string.
+
+  # Examples
+
+      iex> ExWire.Struct.Peer.inet_host_to_uri_host({127, 0, 0, 1})
+      "127.0.0.1"
+
+      iex> ExWire.Struct.Peer.inet_host_to_uri_host({0, 0, 0, 0, 0, 0, 0, 1})
+      "0::0::0::0::0::0::0::1"
+
+      iex> ExWire.Struct.Peer.inet_host_to_uri_host('google.com')
+      "google.com"
+  """
+  @spec inet_host_to_uri_host(:inet.socket_address() | :inet.hostname()) :: String.t()
+  def inet_host_to_uri_host(host = {_, _, _, _}) do
+    host
+    |> Tuple.to_list()
+    |> Enum.join(".")
+  end
+
+  def inet_host_to_uri_host(host) when is_tuple(host) do
+    host
+    |> Tuple.to_list()
+    |> Enum.join("::")
+  end
+
+  def inet_host_to_uri_host(host) when is_list(host) do
+    to_string(host)
+  end
+
+  @doc """
   Creates a node struct from a Kademlia node.
 
   ## Examples
@@ -161,6 +200,7 @@ defmodule ExWire.Struct.Peer do
       ...> } |> ExWire.Struct.Peer.from_node()
       %ExWire.Struct.Peer{
         host: {52, 169, 14, 227},
+        host_name: "52.169.14.227",
         ident: "20c9ad...b733a1",
         port: nil,
         remote_id: <<32, 201, 173, 151, 192, 129, 214, 51, 151, 215, 182, 133, 164,
@@ -173,7 +213,7 @@ defmodule ExWire.Struct.Peer do
   @spec from_node(Node.t()) :: t()
   def from_node(kademlia_node) do
     __MODULE__.new(
-      Enum.join(List.to_tuple(kademlia_node.endpoint.ip), "."),
+      List.to_tuple(kademlia_node.endpoint.ip),
       kademlia_node.endpoint.tcp_port,
       Crypto.bin_to_hex(kademlia_node.public_key)
     )


### PR DESCRIPTION
This patch begins to connect peer discovery to peer to peer connections. This is pretty early going, but I believe it's an important step in the right direction.

A few comments on this PR.

1. If discovery is disabled, we simply connect to the bootnodes.
2. Otherwise, we don't connect to the bootnodes, and instead we ask them for peers. We try to connect to each of those peers.
  a. We should probably keep track of those peers and then choose to connect to individual peers based maybe on distance?
3. When we connect to peers, we try to keep 10 active peers connected (though peers often drop us before we reach this limit).
  a. We currently maintain the count by just connecting to new nodes. We should change this to keep track of a set of available nodes and use more intelligent logic when to connect to those nodes.
4. When we send messages as part of sync, we now send the messages each to a random node to achieve higher parallelism. This is (by no means) a perfect strategy, but it should be a good start. (For example, if one node said it has some block that the other nodes don't know about, we might ask the wrong peer for the block body.)
5. We continue to add config settings to `ExWire.Config` that probably should be re-factored. We opt to wait until we connect CLI before making these updates.