### PR TITLE
Fix Peer Sync

### DIFF
--- a/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
@@ -59,7 +59,7 @@ defmodule ExWire.PeerSupervisor do
 
     results =
       for child <- find_children(node_selector) do
-        Exth.inspect(fn ->
+        Exth.trace(fn ->
           "[PeerSup] Sending #{to_string(packet.__struct__)} packet to peer #{
             inspect(Server.get_peer(child).ident)
           }"

--- a/apps/ex_wire/lib/ex_wire/sync.ex
+++ b/apps/ex_wire/lib/ex_wire/sync.ex
@@ -283,6 +283,8 @@ defmodule ExWire.Sync do
     if block_queue.queue == %{} do
       request_next_block()
     end
+
+    :ok
   end
 
   # Loads sync state from our backing database

--- a/apps/ex_wire/lib/ex_wire/sync.ex
+++ b/apps/ex_wire/lib/ex_wire/sync.ex
@@ -280,9 +280,10 @@ defmodule ExWire.Sync do
   @spec maybe_request_next_block(BlockQueue.t()) :: :ok
   defp maybe_request_next_block(block_queue) do
     # Let's pull a new block if we have none left
-    if block_queue.queue == %{} do
-      request_next_block()
-    end
+    _ =
+      if block_queue.queue == %{} do
+        request_next_block()
+      end
 
     :ok
   end

--- a/apps/ex_wire/test/integration/dev_p2p_communication_test.exs
+++ b/apps/ex_wire/test/integration/dev_p2p_communication_test.exs
@@ -75,13 +75,11 @@ defmodule ExWire.DEVp2pCommunicationTest do
     Peer.new(host, port, node_id)
   end
 
-  @spec get_host() :: String.t()
+  @spec get_host() :: :inet.socket_address()
   defp get_host do
     {:ok, hostname} = :inet.gethostname()
     {:ok, {_, _, _, _, _, [host_tuple]}} = :inet.gethostbyname(hostname)
 
     host_tuple
-    |> :inet.ntoa()
-    |> to_string()
   end
 end


### PR DESCRIPTION
This patch fixes peer sync (syncing against a single node). Previously, once we pulled 100 blocks, we would just stop and do nothing. Now, we correctly continue syncing whenever we have no blocks queued up. While we should be smarter about which blocks to sync and when to ask for more and from which peers, we'll probably end up switching to fast or warp sync before long, which might render this moot. With this patch, syncing against a local parity node works very well (and so does geth before it drops us for not having fast sync enabled).