### PR TITLE
cast messages quicker in ExWire.Sync

### DIFF
--- a/apps/ex_wire/lib/ex_wire/sync.ex
+++ b/apps/ex_wire/lib/ex_wire/sync.ex
@@ -28,6 +28,7 @@ defmodule ExWire.Sync do
   @save_block_interval 100
   @blocks_per_request 100
   @startup_delay 10_000
+  @retry_delay 5_000
 
   @type state :: %{
           chain: Chain.t(),
@@ -99,6 +100,12 @@ defmodule ExWire.Sync do
   def handle_info({:packet, packet, peer}, state) do
     :ok = Exth.trace(fn -> "[Sync] Ignoring packet #{packet.__struct__} from #{peer}" end)
 
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast(:no_children, state) do
+    request_next_block(@retry_delay)
     {:noreply, state}
   end
 


### PR DESCRIPTION
GenServer.cast always returns :ok. The additional checks were unnecessary and can also be made in a separate process which will release the parent proc.