### PR TITLE
get supervision tree based on http and ws configuration

### DIFF
--- a/apps/jsonrpc2/config/config.exs
+++ b/apps/jsonrpc2/config/config.exs
@@ -22,8 +22,8 @@ mana_version =
 
 config :jsonrpc2,
   ipc: [enabled: true, path: Path.join([System.user_home!(), ".ethereum", "mana.ipc"])],
-  http: [enabled: true, port: 3999, interface: :local],
-  ws: [enabled: true, port: 4000, interface: :all],
+  http: [enabled: true, port: 3999, interface: :local, max_connections: 10],
+  ws: [enabled: true, port: 4000, interface: :all, max_connections: 10],
   mana_version: mana_version
 
 import_config "#{Mix.env()}.exs"

--- a/apps/jsonrpc2/config/config.exs
+++ b/apps/jsonrpc2/config/config.exs
@@ -22,8 +22,8 @@ mana_version =
 
 config :jsonrpc2,
   ipc: [enabled: true, path: Path.join([System.user_home!(), ".ethereum", "mana.ipc"])],
-  http: [enabled: true, port: 3999, interface: :local, max_connections: 10],
-  ws: [enabled: true, port: 4000, interface: :all, max_connections: 10],
+  http: [enabled: true, port: 8545, interface: :local, max_connections: 10],
+  ws: [enabled: true, port: 8545, interface: :local, max_connections: 10],
   mana_version: mana_version
 
 import_config "#{Mix.env()}.exs"

--- a/apps/jsonrpc2/config/config.exs
+++ b/apps/jsonrpc2/config/config.exs
@@ -22,8 +22,8 @@ mana_version =
 
 config :jsonrpc2,
   ipc: [enabled: true, path: Path.join([System.user_home!(), ".ethereum", "mana.ipc"])],
-  http: [enabled: true, port: 4000],
-  ws: [enabled: true, port: 4000],
+  http: [enabled: true, port: 3999, interface: :local],
+  ws: [enabled: true, port: 4000, interface: :all],
   mana_version: mana_version
 
 import_config "#{Mix.env()}.exs"

--- a/apps/jsonrpc2/config/test.exs
+++ b/apps/jsonrpc2/config/test.exs
@@ -2,6 +2,6 @@ use Mix.Config
 
 config :jsonrpc2,
   ipc: [enabled: false, path: Enum.join([System.user_home!(), "/.ethereum", "/mana.ipc"])],
-  http: [enabled: false, port: 4000, interface: :local, max_connections: 10],
-  ws: [enabled: false, port: 4000, interface: :local, max_connections: 10],
+  http: [enabled: false, port: 8545, interface: :local, max_connections: 10],
+  ws: [enabled: false, port: 8545, interface: :local, max_connections: 10],
   bridge_mock: JSONRPC2.BridgeSyncMock

--- a/apps/jsonrpc2/config/test.exs
+++ b/apps/jsonrpc2/config/test.exs
@@ -2,6 +2,6 @@ use Mix.Config
 
 config :jsonrpc2,
   ipc: [enabled: false, path: Enum.join([System.user_home!(), "/.ethereum", "/mana.ipc"])],
-  http: [enabled: false, port: 4000, interface: :local],
-  ws: [enabled: false, port: 4000, interface: :local],
+  http: [enabled: false, port: 4000, interface: :local, max_connections: 10],
+  ws: [enabled: false, port: 4000, interface: :local, max_connections: 10],
   bridge_mock: JSONRPC2.BridgeSyncMock

--- a/apps/jsonrpc2/config/test.exs
+++ b/apps/jsonrpc2/config/test.exs
@@ -2,6 +2,6 @@ use Mix.Config
 
 config :jsonrpc2,
   ipc: [enabled: false, path: Enum.join([System.user_home!(), "/.ethereum", "/mana.ipc"])],
-  http: [enabled: false, port: 4000],
-  ws: [enabled: false, port: 4000],
+  http: [enabled: false, port: 4000, interface: :local],
+  ws: [enabled: false, port: 4000, interface: :local],
   bridge_mock: JSONRPC2.BridgeSyncMock

--- a/apps/jsonrpc2/lib/jsonrpc2.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2.ex
@@ -52,12 +52,12 @@ defmodule JSONRPC2 do
     )
   end
 
-  @spec get_ipc_child(Keyword.t()) :: Supervisor.child_spec() | []
+  @spec get_ipc_child(Keyword.t()) :: list(Supervisor.child_spec()) | []
   defp get_ipc_child(enabled: true, path: path) do
     dirname = Path.dirname(path)
     :ok = File.mkdir_p(dirname)
     _ = File.rm(path)
-    TCP.child_spec(SpecHandler, 0, transport_opts: [{:ifaddr, {:local, path}}])
+    [TCP.child_spec(SpecHandler, 0, transport_opts: [{:ifaddr, {:local, path}}])]
   end
 
   defp get_ipc_child(enabled: false, path: _path), do: []

--- a/apps/jsonrpc2/lib/jsonrpc2.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2.ex
@@ -38,20 +38,21 @@ defmodule JSONRPC2 do
     ws = Application.get_env(:jsonrpc2, :ws)
 
     ipc_child = get_ipc_child(ipc)
-    http_ws_child = get_http_ws_child(http, ws)
+    http_configuration = WebSocketHTTP.new(http, :web)
+    ws_configuration = WebSocketHTTP.new(ws, :ws)
 
     children =
-      Enum.filter([ipc_child, http_ws_child], fn
-        nil -> false
-        _ -> true
-      end)
+      Enum.concat(
+        ipc_child,
+        WebSocketHTTP.children(http_configuration, ws_configuration, SpecHandler)
+      )
 
     Supervisor.start_link(children,
       strategy: :one_for_one
     )
   end
 
-  @spec get_ipc_child(Keyword.t()) :: Supervisor.child_spec() | nil
+  @spec get_ipc_child(Keyword.t()) :: Supervisor.child_spec() | []
   defp get_ipc_child(enabled: true, path: path) do
     dirname = Path.dirname(path)
     :ok = File.mkdir_p(dirname)
@@ -59,39 +60,5 @@ defmodule JSONRPC2 do
     TCP.child_spec(SpecHandler, 0, transport_opts: [{:ifaddr, {:local, path}}])
   end
 
-  defp get_ipc_child(enabled: false, path: _path), do: nil
-
-  @spec get_http_ws_child(Keyword.t(), Keyword.t()) :: Supervisor.child_spec() | nil
-  defp get_http_ws_child(
-         _http_config = [enabled: true, port: http_port],
-         _ws_config = [enabled: true, port: ws_port]
-       ) do
-    case http_port do
-      ^ws_port ->
-        WebSocketHTTP.child_spec(:http, :web_ws, SpecHandler, port: http_port)
-
-      _ ->
-        raise(ArgumentError, "HTTP port #{http_port} and WS port #{ws_port} don't match")
-    end
-  end
-
-  defp get_http_ws_child(
-         _http_config = [enabled: true, port: port],
-         _ws_config = [enabled: false, port: _port]
-       ) do
-    WebSocketHTTP.child_spec(:http, :web, SpecHandler, port: port)
-  end
-
-  defp get_http_ws_child(
-         _http_config = [enabled: false, port: _port],
-         _ws_config = [enabled: true, port: port]
-       ) do
-    WebSocketHTTP.child_spec(:http, :ws, SpecHandler, port: port)
-  end
-
-  defp get_http_ws_child(
-         _http_config = [enabled: false, port: _],
-         _ws_config = [enabled: false, port: _]
-       ),
-       do: nil
+  defp get_ipc_child(enabled: false, path: _path), do: []
 end

--- a/apps/jsonrpc2/lib/jsonrpc2/servers/websocket_http.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/servers/websocket_http.ex
@@ -10,8 +10,226 @@ defmodule JSONRPC2.Servers.WebSocketHTTP do
   alias JSONRPC2.Servers.WebSocket
   alias Plug.Cowboy
 
+  @type configuration :: %__MODULE__{
+          type: :ws | :web,
+          enabled: boolean(),
+          port: pos_integer(),
+          interface: :local | :all | :inet.ip_address()
+        }
+
+  defstruct [:type, :enabled, :port, :interface]
+
+  @spec new(Keyword.t(), :ws | :web) :: configuration()
+  def new([enabled: enabled, port: port, interface: interface], type) do
+    %__MODULE__{
+      type: type,
+      enabled: enabled,
+      port: port,
+      interface: interface
+    }
+  end
+
   @doc """
-  Returns a supervisor child spec for the given `handler` via `scheme` with `cowboy_opts`.
+      Four things can happen when it comes to listening to WS and HTTP:
+    - If the provided configuration points to the same port and interface we need to spawn *one* cowboy child with both installed dispatchers.
+    - If the provided configuration points to the same port and *different* interfaces we need to spawn *two* cowboy children where dispatchers are separated.
+    - If the provided configuration points to different ports we need to spawn *two* cowboy children where dispatchers are separated.
+    - Both port and interface are different.
+    Possible interfaces are
+    - All (default)
+    - Local (points to 0.0.0.0)
+    - IP
+    We need to add handler details:
+    --ws-apis=[APIS]
+    --ws-hosts=[HOSTS]
+    --jsonrpc-apis=[APIS]
+    --jsonrpc-hosts=[HOSTS]
+  """
+  @spec children(configuration(), configuration(), module()) ::
+          list(Supervisor.child_spec()) | Supervisor.child_spec() | []
+  def children(
+        http_config,
+        ws_config,
+        handler_module
+      ) do
+    get_http_ws_child(http_config, ws_config, handler_module)
+  end
+
+  @spec get_http_ws_child(configuration(), configuration(), module()) ::
+          list(Supervisor.child_spec())
+          | Supervisor.child_spec()
+          | []
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: port, interface: :all},
+         _ws_config = %__MODULE__{enabled: true, port: port, interface: :all},
+         handler_module
+       ) do
+    child_spec(:web_ws, handler_module, port: port)
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: port, interface: :local},
+         _ws_config = %__MODULE__{enabled: true, port: port, interface: :local},
+         handler_module
+       ) do
+    child_spec(:web_ws, handler_module, ip: {0, 0, 0, 0}, port: port)
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: port, interface: ip},
+         _ws_config = %__MODULE__{enabled: true, port: port, interface: ip},
+         handler_module
+       ) do
+    child_spec(:web_ws, handler_module, ip: ip, port: port)
+  end
+
+  # case 2
+  # raise error when one points to local and other binds all interfaces on the same port
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: port, interface: :all},
+         _ws_config = %__MODULE__{enabled: true, port: port, interface: :local},
+         _handler_module
+       ) do
+    raise(
+      ArgumentError,
+      "Can't bind HTTP on all interfaces and WS on {0,0,0,0} (local) interface with the same port."
+    )
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: port, interface: :local},
+         _ws_config = %__MODULE__{enabled: true, port: port, interface: :all},
+         _handler_module
+       ) do
+    raise(
+      ArgumentError,
+      "Can't bind WS on all interfaces and HTTP on {0,0,0,0} (local) interface with the same port."
+    )
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: port, interface: http_ip},
+         _ws_config = %__MODULE__{enabled: true, port: port, interface: ws_ip},
+         handler_module
+       ) do
+    [
+      child_spec(:web, handler_module, ip: http_ip, port: port),
+      child_spec(:ws, handler_module, ip: ws_ip, port: port)
+    ]
+  end
+
+  # case 3
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: http_port, interface: :all},
+         _ws_config = %__MODULE__{enabled: true, port: ws_port, interface: :all},
+         handler_module
+       ) do
+    [
+      child_spec(:web, handler_module, port: http_port),
+      child_spec(:ws, handler_module, port: ws_port)
+    ]
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: http_port, interface: :local},
+         _ws_config = %__MODULE__{enabled: true, port: ws_port, interface: :local},
+         handler_module
+       ) do
+    [
+      child_spec(:web, handler_module, ip: {0, 0, 0, 0}, port: http_port),
+      child_spec(:ws, handler_module, ip: {0, 0, 0, 0}, port: ws_port)
+    ]
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: http_port, interface: ip},
+         _ws_config = %__MODULE__{enabled: true, port: ws_port, interface: ip},
+         handler_module
+       ) do
+    [
+      child_spec(:web, handler_module, ip: ip, port: http_port),
+      child_spec(:ws, handler_module, ip: ip, port: ws_port)
+    ]
+  end
+
+  # case 4
+  # different interface that doesn't interfere on different ports
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: http_port, interface: :local},
+         _ws_config = %__MODULE__{enabled: true, port: ws_port, interface: :all},
+         handler_module
+       ) do
+    [
+      child_spec(:web, handler_module, ip: {0, 0, 0, 0}, port: http_port),
+      child_spec(:ws, handler_module, port: ws_port)
+    ]
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: http_port, interface: :all},
+         _ws_config = %__MODULE__{enabled: true, port: ws_port, interface: :local},
+         handler_module
+       ) do
+    [
+      child_spec(:web, handler_module, port: http_port),
+      child_spec(:ws, handler_module, ip: {0, 0, 0, 0}, port: ws_port)
+    ]
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: http_port, interface: http_ip},
+         _ws_config = %__MODULE__{enabled: true, port: ws_port, interface: ws_ip},
+         handler_module
+       ) do
+    [
+      child_spec(:web, handler_module, ip: http_ip, port: http_port),
+      child_spec(:ws, handler_module, ip: ws_ip, port: ws_port)
+    ]
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: true, port: port, interface: interface},
+         _ws_config = %__MODULE__{enabled: false, port: _port, interface: _},
+         handler_module
+       ) do
+    case interface do
+      :local ->
+        child_spec(:web, handler_module, ip: {0, 0, 0, 0}, port: port)
+
+      :all ->
+        child_spec(:web, handler_module, port: port)
+
+      ip ->
+        child_spec(:web, handler_module, ip: ip, port: port)
+    end
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: false, port: _port, interface: _},
+         _ws_config = %__MODULE__{enabled: true, port: port, interface: interface},
+         handler_module
+       ) do
+    case interface do
+      :local ->
+        child_spec(:ws, handler_module, ip: {0, 0, 0, 0}, port: port)
+
+      :all ->
+        child_spec(:ws, handler_module, port: port)
+
+      ip ->
+        child_spec(:ws, handler_module, ip: ip, port: port)
+    end
+  end
+
+  defp get_http_ws_child(
+         _http_config = %__MODULE__{enabled: false, port: _, interface: _},
+         _ws_config = %__MODULE__{enabled: false, port: _, interface: _},
+         _handler_module
+       ),
+       do: []
+
+  '''
+  Returns a supervisor child spec for the given `handler` via http scheme with `cowboy_opts`.
 
   Allows you to embed a server directly in your app's supervision tree, rather than letting
   Plug/Cowboy handle it.
@@ -20,26 +238,26 @@ defmodule JSONRPC2.Servers.WebSocketHTTP do
   which are allowed in `cowboy_opts`.
 
   If the server `ref` is not set in `cowboy_opts`, `handler.HTTP` or `handler.HTTPS` is the default.
-  """
-  @spec child_spec(:http | :https, :web_ws | :web | :ws, module, list) :: Supervisor.child_spec()
-  def child_spec(scheme, type, handler, cowboy_opts \\ []) do
-    cowboy_opts = Keyword.merge(cowboy_opts, ref: ref(scheme, JSONRPC2Plug))
-    dispatch = get_dispatcher(type, handler)
-    do_child_spec(scheme, handler, Keyword.merge(cowboy_opts, dispatch))
+  '''
+
+  @spec child_spec(:web_ws | :web | :ws, module, list) :: Supervisor.child_spec()
+  defp child_spec(type, handler, cowboy_opts) do
+    cowboy_opts = Keyword.merge(cowboy_opts, ref: ref(type, JSONRPC2Plug))
+    dispatch = compile_dispatcher(type, handler)
+    do_child_spec(handler, Keyword.merge(cowboy_opts, dispatch))
   end
 
-  defp do_child_spec(scheme, handler, cowboy_opts) do
+  defp do_child_spec(handler, cowboy_opts) do
     Cowboy.child_spec([
-      {:scheme, scheme},
+      {:scheme, :http},
       {:plug, {JSONRPC2Plug, [handler: handler]}},
       {:options, cowboy_opts}
     ])
   end
 
-  defp ref(_scheme = :http, handler), do: Module.concat([handler, HTTP])
-  defp ref(_scheme = :https, handler), do: Module.concat([handler, HTTPS])
+  defp ref(type, handler), do: Module.concat([handler, type, HTTP])
 
-  defp get_dispatcher(:web_ws, handler) do
+  defp compile_dispatcher(:web_ws, handler) do
     dispatch_web_ws(
       WebSocket,
       {:handler, handler},
@@ -48,14 +266,14 @@ defmodule JSONRPC2.Servers.WebSocketHTTP do
     )
   end
 
-  defp get_dispatcher(:web, handler) do
+  defp compile_dispatcher(:web, handler) do
     dispatch_http(
       JSONRPC2Plug,
       JSONRPC2Plug.init(handler: handler)
     )
   end
 
-  defp get_dispatcher(:ws, handler) do
+  defp compile_dispatcher(:ws, handler) do
     dispatch_ws(
       WebSocket,
       {:handler, handler}

--- a/apps/jsonrpc2/lib/jsonrpc2/servers/websocket_http.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/servers/websocket_http.ex
@@ -62,14 +62,13 @@ defmodule JSONRPC2.Servers.WebSocketHTTP do
 
   @spec get_http_ws_child(configuration(), configuration(), module()) ::
           list(Supervisor.child_spec())
-          | Supervisor.child_spec()
           | []
   defp get_http_ws_child(
          http_config = %__MODULE__{enabled: true, port: port, interface: :all},
          _ws_config = %__MODULE__{enabled: true, port: port, interface: :all},
          handler_module
        ) do
-    child_spec(:web_ws, handler_module, http_config)
+    [child_spec(:web_ws, handler_module, http_config)]
   end
 
   defp get_http_ws_child(
@@ -77,7 +76,7 @@ defmodule JSONRPC2.Servers.WebSocketHTTP do
          _ws_config = %__MODULE__{enabled: true, port: port, interface: :local},
          handler_module
        ) do
-    child_spec(:web_ws, handler_module, http_config)
+    [child_spec(:web_ws, handler_module, http_config)]
   end
 
   defp get_http_ws_child(
@@ -85,7 +84,7 @@ defmodule JSONRPC2.Servers.WebSocketHTTP do
          _ws_config = %__MODULE__{enabled: true, port: port, interface: ip},
          handler_module
        ) do
-    child_spec(:web_ws, handler_module, http_config)
+    [child_spec(:web_ws, handler_module, http_config)]
   end
 
   # case 2
@@ -199,7 +198,7 @@ defmodule JSONRPC2.Servers.WebSocketHTTP do
          _ws_config = %__MODULE__{enabled: false},
          handler_module
        ) do
-    child_spec(:web, handler_module, http_config)
+    [child_spec(:web, handler_module, http_config)]
   end
 
   # disabled HTTP
@@ -208,7 +207,7 @@ defmodule JSONRPC2.Servers.WebSocketHTTP do
          ws_config = %__MODULE__{enabled: true},
          handler_module
        ) do
-    child_spec(:ws, handler_module, ws_config)
+    [child_spec(:ws, handler_module, ws_config)]
   end
 
   defp get_http_ws_child(

--- a/apps/jsonrpc2/mix.exs
+++ b/apps/jsonrpc2/mix.exs
@@ -18,7 +18,7 @@ defmodule JSONRPC2.Mixfile do
       description: description(),
       name: "JSONRPC2",
       elixirc_paths: elixirc_paths(Mix.env()),
-      elixirc_options: [warnings_as_errors: true],
+      # elixirc_options: [warnings_as_errors: true],
       elixir: "~> 1.7.4",
       start_permanent: Mix.env() == :prod,
       dialyzer: [

--- a/apps/jsonrpc2/mix.exs
+++ b/apps/jsonrpc2/mix.exs
@@ -18,7 +18,7 @@ defmodule JSONRPC2.Mixfile do
       description: description(),
       name: "JSONRPC2",
       elixirc_paths: elixirc_paths(Mix.env()),
-      # elixirc_options: [warnings_as_errors: true],
+      elixirc_options: [warnings_as_errors: true],
       elixir: "~> 1.7.4",
       start_permanent: Mix.env() == :prod,
       dialyzer: [

--- a/apps/jsonrpc2/test/jsonrpc2/http_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/http_test.exs
@@ -20,7 +20,7 @@ defmodule JSONRPC2.HTTPTest do
 
     {:ok, _pid} =
       start_supervised(
-        WebSocketHTTP.children(http_configuration, ws_configuration, SpecHandlerTest)
+        hd(WebSocketHTTP.children(http_configuration, ws_configuration, SpecHandlerTest))
       )
 
     {:ok, %{port: port}}

--- a/apps/jsonrpc2/test/jsonrpc2/http_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/http_test.exs
@@ -6,9 +6,22 @@ defmodule JSONRPC2.HTTPTest do
 
   setup_all do
     port = 56_752
+    http = Application.get_env(:jsonrpc2, :http)
+
+    http_configuration = WebSocketHTTP.new(http, :web)
+
+    http_configuration =
+      http_configuration
+      |> Map.put(:enabled, true)
+      |> Map.put(:port, port)
+
+    ws = Application.get_env(:jsonrpc2, :ws)
+    ws_configuration = WebSocketHTTP.new(ws, :ws)
 
     {:ok, _pid} =
-      start_supervised(WebSocketHTTP.child_spec(:http, :web, SpecHandlerTest, port: port))
+      start_supervised(
+        WebSocketHTTP.children(http_configuration, ws_configuration, SpecHandlerTest)
+      )
 
     {:ok, %{port: port}}
   end

--- a/apps/jsonrpc2/test/jsonrpc2/websocket_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/websocket_test.exs
@@ -8,8 +8,22 @@ defmodule JSONRPC2.WebSocketTest do
   setup_all do
     port = 56_753
 
+    ws = Application.get_env(:jsonrpc2, :ws)
+
+    ws_configuration = WebSocketHTTP.new(ws, :ws)
+
+    ws_configuration =
+      ws_configuration
+      |> Map.put(:enabled, true)
+      |> Map.put(:port, port)
+
+    http = Application.get_env(:jsonrpc2, :http)
+    http_configuration = WebSocketHTTP.new(http, :web)
+
     {:ok, pid} =
-      start_supervised(WebSocketHTTP.child_spec(:http, :ws, SpecHandlerTest, port: port))
+      start_supervised(
+        WebSocketHTTP.children(http_configuration, ws_configuration, SpecHandlerTest)
+      )
 
     {:ok, client_pid} =
       GenServer.start_link(WebSocketStack, %{external_request_id: 0, port: port})

--- a/apps/jsonrpc2/test/jsonrpc2/websocket_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/websocket_test.exs
@@ -22,7 +22,7 @@ defmodule JSONRPC2.WebSocketTest do
 
     {:ok, pid} =
       start_supervised(
-        WebSocketHTTP.children(http_configuration, ws_configuration, SpecHandlerTest)
+        hd(WebSocketHTTP.children(http_configuration, ws_configuration, SpecHandlerTest))
       )
 
     {:ok, client_pid} =


### PR DESCRIPTION
This is matching Parity and Geth functionality where they allow passing binding interface from the CLI.

```
    --jsonrpc-port=[PORT]
        Specify the port portion of the HTTP JSON-RPC API server. (default: 8545)

    --jsonrpc-interface=[IP]
        Specify the hostname portion of the HTTP JSON-RPC API server, IP should be an interface's IP address, or all
        (all interfaces) or local. (default: local)

--ws-port=[PORT]
        Specify the port portion of the WebSockets JSON-RPC server. (default: 8546)

    --ws-interface=[IP]
        Specify the hostname portion of the WebSockets JSON-RPC server, IP should be an interface's IP address, or all
        (all interfaces) or local. (default: local)
```