### PR TITLE
fix extcodehash common test

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Ethereum common tests are created for all clients to test against. See the [comm
 | TangerineWhistle  | 100% (1270/1270)          | 100% (1120/1120)            | ✓         |
 | SpuriousDragon    | 100% (1201/1201)          | 100% (1180/1180)            | ✓         |
 | Byzantium         | 100% (4954/4954)          | 100% (4800/4800)            | ✓         |
-| Constantinople    | 99.9% (10590/10591)       | 99.9% (10552/10553)         | ✓         |
+| Constantinople    | 99.9% (10592/10593)       | 99.9% (10552/10553)         | ✓         |
 
 View the community [Constantinople Project Tracker](https://github.com/ethereum/pm/issues/53).
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Ethereum common tests are created for all clients to test against. See the [comm
 | TangerineWhistle  | 100% (1270/1270)          | 100% (1120/1120)            | ✓         |
 | SpuriousDragon    | 100% (1201/1201)          | 100% (1180/1180)            | ✓         |
 | Byzantium         | 100% (4954/4954)          | 100% (4800/4800)            | ✓         |
-| Constantinople    | 99.9% (10592/10593)       | 99.9% (10552/10553)         | ✓         |
+| Constantinople    | 100% (10593/10593)        | 100% (10553/10553)          | ✓         |
 
 View the community [Constantinople Project Tracker](https://github.com/ethereum/pm/issues/53).
 

--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -26,7 +26,7 @@ defmodule Blockchain.Account do
           nonce: integer(),
           balance: EVM.Wei.t(),
           storage_root: EVM.trie_root(),
-          code_hash: MerklePatriciaTree.Trie.key()
+          code_hash: MerklePatriciaTree.Trie.key() | nil
         }
 
   @doc """
@@ -518,7 +518,7 @@ defmodule Blockchain.Account do
 
       iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
       ...> |> Blockchain.Account.machine_code(<<0x01::160>>)
-      {:ok, <<>>}
+      :not_found
 
       iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
       ...> |> Blockchain.Account.put_code(<<0x01::160>>, <<1, 2, 3>>)

--- a/apps/blockchain/lib/blockchain/account/repo.ex
+++ b/apps/blockchain/lib/blockchain/account/repo.ex
@@ -599,6 +599,22 @@ defmodule Blockchain.Account.Repo do
   end
 
   @spec cache_and_get_code(t(), Address.t(), Account.t()) :: {t(), {:ok, binary()} | :not_found}
+  defp cache_and_get_code(account_repo, address, %Account{code_hash: nil}) do
+    value_to_cache = ""
+    {status, account, _} = account_from_cache(account_repo.cache, address)
+
+    updated_cache =
+      Cache.update_account(
+        account_repo.cache,
+        address,
+        {status, account, {:clean, value_to_cache}}
+      )
+
+    repo_with_cached_code = %{account_repo | cache: updated_cache}
+
+    {repo_with_cached_code, {:ok, value_to_cache}}
+  end
+
   defp cache_and_get_code(account_repo, address, account) do
     found_code = Account.machine_code(account_repo.state, account)
 

--- a/apps/blockchain/lib/blockchain/account/repo.ex
+++ b/apps/blockchain/lib/blockchain/account/repo.ex
@@ -107,7 +107,7 @@ defmodule Blockchain.Account.Repo do
 
       true ->
         {_repo, to_account, to_account_code} = account_with_code(account_repo, to)
-        to_account = to_account || %Account{}
+        to_account = to_account || Account.not_persistent_account()
 
         new_from_account = %{from_account | balance: from_account.balance - wei}
         new_to_account = %{to_account | balance: to_account.balance + wei}
@@ -127,7 +127,7 @@ defmodule Blockchain.Account.Repo do
 
     {_repo, account, code} = account_with_code(account_repo, address)
 
-    account = account || %Account{}
+    account = account || Account.not_persistent_account()
 
     updated_account = %{account | balance: account.balance + value}
 
@@ -160,7 +160,7 @@ defmodule Blockchain.Account.Repo do
 
     {_repo, account, _} = account_with_code(account_repo, address)
 
-    updated_account = %{(account || %Account{}) | code_hash: kec}
+    updated_account = %{(account || Account.not_persistent_account()) | code_hash: kec}
 
     updated_cache =
       Cache.update_account(

--- a/apps/blockchain/lib/eth_common_test/state_test_runner.ex
+++ b/apps/blockchain/lib/eth_common_test/state_test_runner.ex
@@ -147,9 +147,11 @@ defmodule EthCommonTest.StateTestRunner do
         storage_root: storage.root_hash
       }
 
+      address = maybe_hex(address)
+
       state
-      |> Account.put_account(maybe_hex(address), new_account)
-      |> Account.put_code(maybe_hex(address), maybe_hex(account["code"]))
+      |> Account.put_account(address, new_account)
+      |> Account.put_code(address, maybe_hex(account["code"]))
     end)
   end
 

--- a/apps/blockchain/scripts/evm_runner.ex
+++ b/apps/blockchain/scripts/evm_runner.ex
@@ -54,13 +54,15 @@ defmodule EVMRunner do
 
     {gas_remaining, _sub_state, _exec_env, result} = VM.run(gas_limit, exec_env)
 
-    _ = Logger.debug(fn ->
-      "Gas Remaining: #{gas_remaining}"
-    end)
+    _ =
+      Logger.debug(fn ->
+        "Gas Remaining: #{gas_remaining}"
+      end)
 
-    _ = Logger.debug(fn ->
-      "Result: #{inspect(result)}"
-    end)
+    _ =
+      Logger.debug(fn ->
+        "Result: #{inspect(result)}"
+      end)
   end
 end
 

--- a/apps/blockchain/test/blockchain/blockchain_state_test.exs
+++ b/apps/blockchain/test/blockchain/blockchain_state_test.exs
@@ -7,7 +7,7 @@ defmodule Blockchain.BlockchainStateTest do
 
   @failing_tests %{
     "Byzantium" => [],
-    "Constantinople" => ["stBugs/randomStatetestDEFAULT-Tue_07_58_41-15153-575192"],
+    "Constantinople" => [],
     "Frontier" => [],
     "Homestead" => [],
     "HomesteadToDaoAt5" => [],

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -17,9 +17,7 @@ defmodule BlockchainTest do
     "TangerineWhistle" => [],
     "SpuriousDragon" => [],
     "Byzantium" => [],
-    "Constantinople" => [
-      "GeneralStateTests/stBugs/randomStatetestDEFAULT-Tue_07_58_41-15153-575192_d0g0v0.json"
-    ],
+    "Constantinople" => [],
     "EIP158ToByzantiumAt5" => [],
     # the rest are not implemented yet
     "FrontierToHomesteadAt5" => [],

--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -1,8 +1,5 @@
 defmodule EVM.Operation.EnvironmentalInformation do
   alias EVM.{Address, ExecEnv, Helpers, Memory, Operation, Stack}
-  alias ExthCrypto.Hash.Keccak
-
-  @empty_keccak Keccak.kec(<<>>)
 
   @doc """
   Get address of currently executing account.
@@ -305,7 +302,7 @@ defmodule EVM.Operation.EnvironmentalInformation do
     {updated_exec_env, hash} = ExecEnv.code_hash(exec_env, wrapped_address)
 
     stack_value =
-      if is_nil(hash) || hash == @empty_keccak do
+      if is_nil(hash) do
         0
       else
         hash

--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -1,5 +1,8 @@
 defmodule EVM.Operation.EnvironmentalInformation do
   alias EVM.{Address, ExecEnv, Helpers, Memory, Operation, Stack}
+  alias ExthCrypto.Hash.Keccak
+
+  @empty_keccak Keccak.kec(<<>>)
 
   @doc """
   Get address of currently executing account.
@@ -302,7 +305,7 @@ defmodule EVM.Operation.EnvironmentalInformation do
     {updated_exec_env, hash} = ExecEnv.code_hash(exec_env, wrapped_address)
 
     stack_value =
-      if is_nil(hash) do
+      if is_nil(hash) || hash == @empty_keccak do
         0
       else
         hash


### PR DESCRIPTION
Changes: 
- fix `excodehash` op code for empty accounts (fixes https://github.com/mana-ethereum/mana/issues/656)
- update ethereum common tests submodule (https://github.com/ethereum/tests/pull/552)