### PR TITLE
Adds pow_light function to Ethash

### DIFF
--- a/apps/blockchain/test/blockchain/ethash_test.exs
+++ b/apps/blockchain/test/blockchain/ethash_test.exs
@@ -102,7 +102,6 @@ defmodule Blockchain.EthashTest do
     end
   end
 
-  @tag :skip
   describe "pow_light/4" do
     test "calculates proof-of-work with light dataset" do
       cache_size = 1024


### PR DESCRIPTION
This relates to #541

Description
===========

Adds the light version of the Proof-of-work Ethash function.

This version uses an in-memory cache version for data aggregation instead of the full dataset.

Note: We extract the common functionality of `Ethash.pow_full` and `Ethash.pow_light` into a private `pow` function.

Wiki description
----------------

We closely follow the implementation outlined in the [wiki](https://github.com/ethereum/wiki/wiki/Ethash#main-loop), so I include a copy of it here for convenience. 

![screen shot 2018-11-26 at 3 42 42 pm](https://user-images.githubusercontent.com/3245976/49041015-1125a880-f192-11e8-9bcf-a82cc97b8c71.png)
