### PR TITLE
Optimize Ethash cache generation in two places

### DIFF
--- a/apps/blockchain/lib/blockchain/ethash.ex
+++ b/apps/blockchain/lib/blockchain/ethash.ex
@@ -301,14 +301,22 @@ defmodule Blockchain.Ethash do
   defp initial_cache(seed, cache_size) do
     adjusted_cache_size = div(cache_size, @j_hashbytes)
 
-    for i <- 0..(adjusted_cache_size - 1) do
-      cache_element(i, seed)
-    end
+    do_initial_cache(0, adjusted_cache_size - 1, seed, [])
   end
 
-  defp cache_element(0, seed), do: Keccak.kec512(seed)
+  defp do_initial_cache(limit, limit, _seed, acc = [previous | _rest]) do
+    result = Keccak.kec512(previous)
 
-  defp cache_element(element, seed) do
-    Keccak.kec512(cache_element(element - 1, seed))
+    [result | acc] |> Enum.reverse()
+  end
+
+  defp do_initial_cache(0, limit, seed, []) do
+    result = Keccak.kec512(seed)
+    do_initial_cache(1, limit, seed, [result])
+  end
+
+  defp do_initial_cache(element, limit, seed, acc = [previous | _rest]) do
+    result = Keccak.kec512(previous)
+    do_initial_cache(element + 1, limit, seed, [result | acc])
   end
 end

--- a/apps/blockchain/lib/blockchain/ethash/rand_memo_hash.ex
+++ b/apps/blockchain/lib/blockchain/ethash/rand_memo_hash.ex
@@ -4,6 +4,8 @@ defmodule Blockchain.Ethash.RandMemoHash do
 
   use Bitwise
 
+  @type optimized_cache :: %{non_neg_integer() => <<_::512>>}
+
   @doc """
   Computes the RandMemoHash algorithm for a list of binaries (as lists) as is
   outlined in Appendix J of the Yellow Paper.
@@ -20,20 +22,37 @@ defmodule Blockchain.Ethash.RandMemoHash do
   def hash(original_cache) do
     n = length(original_cache)
 
+    cache = optimized_cache(original_cache)
+
     0..(n - 1)
-    |> Enum.reduce(original_cache, fn index, modified_cache ->
+    |> Enum.reduce(cache, fn index, modified_cache ->
       rmh(index, n, modified_cache)
+    end)
+    |> return_cache_to_list()
+  end
+
+  defp return_cache_to_list(cache_as_map) do
+    Enum.map(cache_as_map, fn {_k, v} -> v end)
+  end
+
+  defp optimized_cache(original_cache) do
+    original_cache
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {v, k}, acc ->
+      Map.put(acc, k, v)
     end)
   end
 
-  @spec rmh(non_neg_integer(), non_neg_integer(), Ethash.cache()) :: Ethash.cache()
+  @spec rmh(integer(), non_neg_integer(), optimized_cache()) :: optimized_cache()
   defp rmh(i, n, cache) do
-    first_element = Enum.at(cache, first_index(i, n))
-    second_element = Enum.at(cache, second_index(i, n, cache))
+    first_index = first_index(i, n)
+    second_index = second_index(i, n, cache)
+
+    %{^first_index => first_element, ^second_index => second_element} = cache
 
     updated_element = Keccak.kec512(:crypto.exor(first_element, second_element))
 
-    List.replace_at(cache, i, updated_element)
+    Map.put(cache, i, updated_element)
   end
 
   @spec first_index(integer(), non_neg_integer()) :: integer()
@@ -41,9 +60,9 @@ defmodule Blockchain.Ethash.RandMemoHash do
     Integer.mod(i - 1 + n, n)
   end
 
-  @spec second_index(integer(), integer(), Ethash.cache()) :: integer()
+  @spec second_index(integer(), non_neg_integer(), optimized_cache()) :: integer()
   defp second_index(i, n, cache) do
-    cache_element = Enum.at(cache, i)
+    %{^i => cache_element} = cache
 
     <<header::size(8), _rest::binary>> = cache_element
 


### PR DESCRIPTION
This is part of #541 

Why?
===

When attempting to run the ethereum common tests for the Ethash PoW, it became apparent that the cache generation is slow.

Note: the tests are not included in this commit because they are not yet passing since they take too long.

What?
=====

This commit includes two optimizations:

1. The initial cache generation (based on a seed hash) recurses N times, and each element is the Keccak 512 of the previous element. Previous to this commit, we were starting with the first element and going to element N, without keeping an accumulated list of elements. So element N would generate all previous elements only for its own calculation. Now we simply keep the values so that we only run through the initial cache generation step N times. (where N is cache_size/@j_hasbytes).

2. When performing the RandMemoHash algorithm, we were using an elixir List since that is the format of the cache. But we must constantly update that list as part of the RandMemoHash algorithm. Since getting and updating elements of a linked list is slow, we now transform the cache into a Map with the indexes as keys. This allows for faster accessing and updating of the cache.