### PR TITLE
Adjust CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - restore_cache:
           keys:
@@ -31,13 +29,7 @@ jobs:
           no_output_timeout: 2400
 
       - save_cache:
-          key: v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-          paths: "deps"
-      - save_cache:
-          key: v13-mix-cache-{{ .Branch }}
-          paths: "deps"
-      - save_cache:
-          key: v13-mix-cache
+          key: v13-mix-cache-{{ checksum "mix.lock" }}
           paths: "deps"
 
       - save_cache:
@@ -98,9 +90,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix test --exclude pending
 
@@ -126,9 +116,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: EXT_IP_ADDRESS=$(curl ifconfig.co) mix test --only network
 
@@ -154,9 +142,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix cmd --app blockchain mix test --exclude test --include Frontier
 
@@ -182,9 +168,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix cmd --app blockchain mix test --exclude test --include Homestead
 
@@ -210,9 +194,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix cmd --app blockchain mix test --exclude test --include HomesteadToDaoAt5
 
@@ -238,9 +220,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix cmd --app blockchain mix test --exclude test --include TangerineWhistle
 
@@ -266,9 +246,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix cmd --app blockchain mix test --exclude test --include SpuriousDragon
 
@@ -294,9 +272,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run:
           command: mix cmd --app blockchain mix test --exclude test --include Byzantium
@@ -324,9 +300,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{ checksum "mix.lock" }}
 
       - run:
           command: mix cmd --app blockchain mix test --exclude test --include Constantinople
@@ -355,9 +329,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-mix-cache-{{ .Branch }}
-            - v13-mix-cache
+            - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,6 @@ jobs:
           keys:
             - v13-mix-cache-{{ checksum "mix.lock" }}
 
-      - restore_cache:
-          keys:
-            - v13-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
-
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
 
       - run:
@@ -31,16 +25,6 @@ jobs:
       - save_cache:
           key: v13-mix-cache-{{ checksum "mix.lock" }}
           paths: "deps"
-
-      - save_cache:
-          key: v13-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-          paths: "_build"
-      - save_cache:
-          key: v13-build-cache-{{ .Branch }}
-          paths: "_build"
-      - save_cache:
-          key: v13-build-cache
-          paths: "_build"
 
       - run:
           name: Compile
@@ -85,11 +69,6 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
-
-      - restore_cache:
-          keys:
             - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix test --exclude pending
@@ -108,11 +87,6 @@ jobs:
 
       - run: mix local.hex --force
       - run: mix local.rebar --force
-
-      - restore_cache:
-          keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
 
       - restore_cache:
           keys:
@@ -137,11 +111,6 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
-
-      - restore_cache:
-          keys:
             - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix cmd --app blockchain mix test --exclude test --include Frontier
@@ -160,11 +129,6 @@ jobs:
 
       - run: mix local.hex --force
       - run: mix local.rebar --force
-
-      - restore_cache:
-          keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
 
       - restore_cache:
           keys:
@@ -189,11 +153,6 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
-
-      - restore_cache:
-          keys:
             - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix cmd --app blockchain mix test --exclude test --include HomesteadToDaoAt5
@@ -212,11 +171,6 @@ jobs:
 
       - run: mix local.hex --force
       - run: mix local.rebar --force
-
-      - restore_cache:
-          keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
 
       - restore_cache:
           keys:
@@ -241,11 +195,6 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
-
-      - restore_cache:
-          keys:
             - v13-mix-cache-{{ checksum "mix.lock" }}
 
       - run: mix cmd --app blockchain mix test --exclude test --include SpuriousDragon
@@ -264,11 +213,6 @@ jobs:
 
       - run: mix local.hex --force
       - run: mix local.rebar --force
-
-      - restore_cache:
-          keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
 
       - restore_cache:
           keys:
@@ -295,11 +239,6 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
-
-      - restore_cache:
-          keys:
             - v13-mix-cache-{ checksum "mix.lock" }}
 
       - run:
@@ -321,11 +260,6 @@ jobs:
 
       - run: mix local.hex --force
       - run: mix local.rebar --force
-
-      - restore_cache:
-          keys:
-            - v13-build-cache-{{ .Branch }}
-            - v13-build-cache
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,6 @@ jobs:
 
       - restore_cache:
           keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
-
-      - restore_cache:
-          keys:
             - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
@@ -108,12 +102,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
 
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
-
       - run: mix test --exclude pending
 
   network:
@@ -141,12 +129,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
-
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
 
       - run: EXT_IP_ADDRESS=$(curl ifconfig.co) mix test --only network
 
@@ -176,12 +158,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
 
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
-
       - run: mix cmd --app blockchain mix test --exclude test --include Frontier
 
   Homestead:
@@ -209,12 +185,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
-
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include Homestead
 
@@ -244,12 +214,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
 
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
-
       - run: mix cmd --app blockchain mix test --exclude test --include HomesteadToDaoAt5
 
   TangerineWhistle:
@@ -277,12 +241,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
-
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
 
       - run: mix cmd --app blockchain mix test --exclude test --include TangerineWhistle
 
@@ -312,12 +270,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
 
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
-
       - run: mix cmd --app blockchain mix test --exclude test --include SpuriousDragon
 
   Byzantium:
@@ -345,12 +297,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
-
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
 
       - run:
           command: mix cmd --app blockchain mix test --exclude test --include Byzantium
@@ -382,12 +328,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
 
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
-
       - run:
           command: mix cmd --app blockchain mix test --exclude test --include Constantinople
           no_output_timeout: 2400
@@ -418,12 +358,6 @@ jobs:
             - v13-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
             - v13-mix-cache-{{ .Branch }}
             - v13-mix-cache
-
-      - restore_cache:
-          keys:
-            - v13-env-cache-{{ arch }}-{{ .Branch }}
-            - v13-env-cache-{{ .Branch }}
-            - v13-env-cache
 
       - restore_cache:
           keys:


### PR DESCRIPTION
* Removes the env cache (it was not being saved anywhere, so would either always be missing or
always out of date).
* Only caches `deps` based on the `mix.lock` checksum.
* Stops caching `_build` between builds, just pass it between jobs using `persist_to_workspace`.