### PR TITLE
Allow Failure from Disconnected Peer

### DIFF
--- a/apps/ex_wire/lib/ex_wire/p2p/manager.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/manager.ex
@@ -107,7 +107,6 @@ defmodule ExWire.P2P.Manager do
             queued_data: <<>>
         }
 
-        # TODO: What do we do about unknown packets?
         conn_after_handle =
           case get_packet(packet_type, packet_data) do
             {:ok, packet_mod, packet} ->
@@ -161,7 +160,7 @@ defmodule ExWire.P2P.Manager do
         %{conn | session: new_session}
 
       {_, :peer_disconnect} ->
-        :ok = TCP.shutdown(conn.socket)
+        _ = TCP.shutdown(conn.socket)
 
         conn
 
@@ -262,9 +261,9 @@ defmodule ExWire.P2P.Manager do
 
     :ok =
       Logger.debug(fn ->
-        "[Network] [#{peer}] Sending packet #{inspect(packet_mod)} to #{peer.host_name} (##{
-          conn.sent_message_count + 1
-        })"
+        "[Network] [#{peer}] Sending packet #{inspect(packet_mod)} (#{
+          inspect(packet_type, base: :hex)
+        }) to #{peer.host_name} (##{conn.sent_message_count + 1})"
       end)
 
     packet_data = apply(packet_mod, :serialize, [packet])


### PR DESCRIPTION
If a peer asks to disconnect, it probably will terminate the connection immediately after asking to disconnect. By the time we get to processing that message, we try to disconnect to an already disconnected peer, which causes the connection manager to crash (since we're matching :ok when trying to disconnect to a disconnected peer). As such, we simply allow any result from disconnect, since it will disconnect or it's been disconnected.