### PR TITLE
Stream Batch Updates for Trie

### DIFF
--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db.ex
@@ -21,7 +21,7 @@ defmodule MerklePatriciaTree.DB do
   @callback get(db_ref, MerklePatriciaTree.Trie.key()) :: {:ok, value} | :not_found
   @callback put!(db_ref, MerklePatriciaTree.Trie.key(), value) :: :ok
   @callback delete!(db_ref(), MerklePatriciaTree.Trie.key()) :: :ok
-  @callback batch_put!(db_ref, [{MerklePatriciaTree.Trie.key(), value}]) :: :ok
+  @callback batch_put!(db_ref, Enumerable.t(), integer()) :: :ok
 
   @doc """
   Retrieves a key from the database.
@@ -102,8 +102,8 @@ defmodule MerklePatriciaTree.DB do
   @doc """
   Stores key-value pairs in the database.
   """
-  @spec batch_put!(db_ref, [{MerklePatriciaTree.Trie.key(), value}]) :: :ok
-  def batch_put!(_db = {db_mod, db_ref}, key_value_pairs) do
-    db_mod.batch_put!(db_ref, key_value_pairs)
+  @spec batch_put!(db_ref, Enumerable.t(), integer()) :: :ok
+  def batch_put!(_db = {db_mod, db_ref}, key_value_pairs, batch_size) do
+    db_mod.batch_put!(db_ref, key_value_pairs, batch_size)
   end
 end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/ets.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/db/ets.ex
@@ -51,9 +51,14 @@ defmodule MerklePatriciaTree.DB.ETS do
   Stores key-value pairs in the database.
   """
   @impl true
-  def batch_put!(db_ref, key_value_pairs) do
-    case :ets.insert(db_ref, key_value_pairs) do
-      true -> :ok
-    end
+  def batch_put!(db_ref, key_value_pairs, batch_size) do
+    key_value_pairs
+    |> Stream.chunk_every(batch_size)
+    |> Stream.each(fn pairs ->
+      true = :ets.insert(db_ref, pairs)
+    end)
+    |> Stream.run()
+
+    :ok
   end
 end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie.ex
@@ -164,8 +164,8 @@ defmodule MerklePatriciaTree.Trie do
   end
 
   @impl true
-  def put_batch_raw_keys!(trie, key_value_pairs) do
-    DB.batch_put!(trie.db, key_value_pairs)
+  def put_batch_raw_keys!(trie, key_value_pairs, batch_size) do
+    DB.batch_put!(trie.db, key_value_pairs, batch_size)
 
     trie
   end

--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie_storage.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie_storage.ex
@@ -10,107 +10,111 @@ defmodule MerklePatriciaTree.TrieStorage do
   @type t :: struct()
 
   @callback fetch_node(t) :: Node.trie_node()
-
   @callback put_node(node, t) :: nil | binary()
-
   @callback remove_key(t, Trie.key()) :: t
-
   @callback remove_subtrie_key(t, Trie.root_hash(), Trie.key()) :: {t, t}
-
   @callback update_key(t(), Trie.key(), ExRLP.t() | nil) :: t
-
   @callback update_subtrie_key(t(), Trie.root_hash(), Trie.key(), ExRLP.t() | nil) :: {t, t}
-
   @callback put_raw_key!(t(), binary(), binary()) :: t()
-
-  @callback put_batch_raw_keys!(t(), [{binary(), binary()}]) :: t()
-
+  @callback put_batch_raw_keys!(t(), Enumerate.t(), integer()) :: t()
   @callback get_raw_key(t(), binary()) :: {:ok, binary()} | :not_found
-
   @callback get_key(t(), Trie.key()) :: nil | binary()
-
   @callback get_subtrie_key(t(), Trie.root_hash(), Trie.key()) :: nil | binary()
-
   @callback into(binary(), t) :: t
-
   @callback root_hash(t()) :: Trie.root_hash()
-
   @callback set_root_hash(t(), Trie.root_hash()) :: t()
-
   @callback store(t) :: t
-
   @callback permanent_db(t) :: DB.db()
-
   @callback commit!(t) :: t
 
+  @default_batch_size 1000
+
+  @spec fetch_node(t) :: Node.trie_node()
   def fetch_node(implementation) do
     storage(implementation).fetch_node(implementation)
   end
 
+  @spec put_node(node(), t()) :: nil | binary()
   def put_node(node, implementation) do
     storage(implementation).put_node(node, implementation)
   end
 
+  @spec remove_key(t(), Trie.key()) :: t()
   def remove_key(implementation, key) do
     storage(implementation).remove_key(implementation, key)
   end
 
+  @spec remove_subtrie_key(t, Trie.root_hash(), Trie.key()) :: {t, t}
   def remove_subtrie_key(implementation, root_hash, key) do
     storage(implementation).remove_subtrie_key(implementation, root_hash, key)
   end
 
+  @spec update_key(t(), Trie.key(), ExRLP.t() | nil) :: t
   def update_key(implementation, key, value) do
     storage(implementation).update_key(implementation, key, value)
   end
 
+  @spec update_subtrie_key(t(), Trie.root_hash(), Trie.key(), ExRLP.t() | nil) :: {t, t}
   def update_subtrie_key(implementation, root_hash, key, value) do
     storage(implementation).update_subtrie_key(implementation, root_hash, key, value)
   end
 
+  @spec put_raw_key!(t(), binary(), binary()) :: t()
   def put_raw_key!(implementation, key, value) do
     storage(implementation).put_raw_key!(implementation, key, value)
   end
 
-  def put_batch_raw_keys!(implementation, pairs) do
-    storage(implementation).put_batch_raw_keys!(implementation, pairs)
+  @spec put_batch_raw_keys!(t(), Enumerate.t(), integer()) :: t()
+  def put_batch_raw_keys!(implementation, pairs, batch_size \\ @default_batch_size) do
+    storage(implementation).put_batch_raw_keys!(implementation, pairs, batch_size)
   end
 
+  @spec get_raw_key(t(), binary()) :: {:ok, binary()} | :not_found
   def get_raw_key(implementation, key) do
     storage(implementation).get_raw_key(implementation, key)
   end
 
+  @spec get_key(t(), Trie.key()) :: nil | binary()
   def get_key(implementation, key) do
     storage(implementation).get_key(implementation, key)
   end
 
+  @spec get_subtrie_key(t(), Trie.root_hash(), Trie.key()) :: nil | binary()
   def get_subtrie_key(implementation, root_hash, key) do
     storage(implementation).get_subtrie_key(implementation, root_hash, key)
   end
 
+  @spec into(binary(), t) :: t
   def into(root_hash, implementation) do
     storage(implementation).into(root_hash, implementation)
   end
 
+  @spec root_hash(t()) :: Trie.root_hash()
   def root_hash(implementation) do
     storage(implementation).root_hash(implementation)
   end
 
+  @spec set_root_hash(t(), Trie.root_hash()) :: t()
   def set_root_hash(implementation, root_hash) do
     storage(implementation).set_root_hash(implementation, root_hash)
   end
 
+  @spec store(t) :: t
   def store(implementation) do
     storage(implementation).store(implementation)
   end
 
+  @spec commit!(t) :: t
   def commit!(implementation) do
     storage(implementation).commit!(implementation)
   end
 
+  @spec permanent_db(t) :: DB.db()
   def permanent_db(implementation) do
     storage(implementation).permanent_db(implementation)
   end
 
+  @spec storage(t) :: atom()
   defp storage(implementation) do
     implementation.__struct__
   end

--- a/apps/merkle_patricia_tree/mix.exs
+++ b/apps/merkle_patricia_tree/mix.exs
@@ -50,7 +50,8 @@ defmodule MerklePatriciaTree.Mixfile do
     [
       {:ex_rlp, "~> 0.5.0"},
       {:exth_crypto, in_umbrella: true},
-      {:rocksdb, "~> 0.23.2"}
+      {:rocksdb, "~> 0.23.2"},
+      {:jason, "~> 1.1"}
     ]
   end
 end

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
@@ -283,7 +283,7 @@ defmodule MerklePatriciaTree.CachingTrieTest do
     end
   end
 
-  describe "put_batch_raw_keys!/2" do
+  describe "put_batch_raw_keys!/3" do
     test "puts a batch of keys to db_changes", %{disk_trie: disk_trie} do
       caching_trie = CachingTrie.new(disk_trie)
 
@@ -293,7 +293,7 @@ defmodule MerklePatriciaTree.CachingTrieTest do
         {"ruby", "crystal"}
       ]
 
-      updated_caching_trie = CachingTrie.put_batch_raw_keys!(caching_trie, pairs)
+      updated_caching_trie = CachingTrie.put_batch_raw_keys!(caching_trie, pairs, 2)
 
       assert updated_caching_trie.db_changes == %{
                "elixir" => "erlang",

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/ets_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/ets_test.exs
@@ -60,7 +60,7 @@ defmodule MerklePatriciaTree.DB.ETSTest do
         assert ETS.get(db_ref, key) == :not_found
       end)
 
-      assert ETS.batch_put!(db_ref, pairs) == :ok
+      assert ETS.batch_put!(db_ref, pairs, 2) == :ok
 
       Enum.each(pairs, fn {key, value} ->
         assert ETS.get(db_ref, key) == {:ok, value}

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/rocksdb_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/rocksdb_test.exs
@@ -62,7 +62,7 @@ defmodule MerklePatriciaTree.DB.RocksDBTest do
     end
   end
 
-  describe "batch_put!/2" do
+  describe "batch_put!/3" do
     test "puts key-value pairs to db" do
       db_name = String.to_charlist("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
       {_db, db_ref} = RocksDB.init(db_name)
@@ -77,7 +77,7 @@ defmodule MerklePatriciaTree.DB.RocksDBTest do
         assert RocksDB.get(db_ref, key) == :not_found
       end)
 
-      assert RocksDB.batch_put!(db_ref, pairs) == :ok
+      assert RocksDB.batch_put!(db_ref, pairs, 2) == :ok
 
       Enum.each(pairs, fn {key, value} ->
         assert RocksDB.get(db_ref, key) == {:ok, value}

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/trie_test.exs
@@ -422,7 +422,7 @@ defmodule MerklePatriciaTree.TrieTest do
     end
   end
 
-  describe "put_batch_raw_keys!/2" do
+  describe "put_batch_raw_keys!/3" do
     test "saves key-value pairs to db" do
       trie = MerklePatriciaTree.Test.random_ets_db() |> Trie.new()
 
@@ -436,7 +436,7 @@ defmodule MerklePatriciaTree.TrieTest do
         assert Trie.get_raw_key(trie, key) == :not_found
       end)
 
-      Trie.put_batch_raw_keys!(trie, pairs)
+      Trie.put_batch_raw_keys!(trie, pairs, 1)
 
       Enum.each(pairs, fn {key, value} ->
         assert Trie.get_raw_key(trie, key) == {:ok, value}


### PR DESCRIPTION
Previously, when we had a large number of updates, we would send them all to the NIF at once. For a several megabyte update (which is common in warp sync), this would effectively crash the erlang runtime system (since NIF cannot be pre-empted). This patch changes the system to instead stream the updates in batches. The allows us to play nice with pre-emption, allows for faster and smaller garbage collection and keeps the overall memory footprint significantly lower.