### PR TITLE
set disk trie root hash from in-memory trie after commit

### DIFF
--- a/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
+++ b/apps/merkle_patricia_tree/lib/merkle_patricia_tree/caching_trie.ex
@@ -156,7 +156,7 @@ defmodule MerklePatriciaTree.CachingTrie do
 
   @impl true
   def commit!(caching_trie) do
-    trie = caching_trie.trie
+    trie = %{caching_trie.trie | root_hash: caching_trie.in_memory_trie.root_hash}
 
     trie_updates = get_all_key_value_pairs(caching_trie.in_memory_trie)
     db_updates = Map.to_list(caching_trie.db_changes)

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/caching_trie_test.exs
@@ -246,7 +246,8 @@ defmodule MerklePatriciaTree.CachingTrieTest do
       assert Trie.get_subtrie_key(disk_trie, caching_trie.in_memory_trie.root_hash, "elixir") ==
                nil
 
-      CachingTrie.commit!(caching_trie)
+      in_memory_trie_root_hash = caching_trie.in_memory_trie.root_hash
+      committed_trie = CachingTrie.commit!(caching_trie)
 
       assert Trie.get_subtrie_key(disk_trie, caching_trie.in_memory_trie.root_hash, "key1") ==
                "value1"
@@ -256,6 +257,9 @@ defmodule MerklePatriciaTree.CachingTrieTest do
 
       assert Trie.get_subtrie_key(disk_trie, caching_trie.in_memory_trie.root_hash, "elixir") ==
                "erlang"
+
+      assert committed_trie.trie.root_hash == in_memory_trie_root_hash
+      refute committed_trie.trie.root_hash == disk_trie.root_hash
     end
 
     test "commits raw cache" do
@@ -275,11 +279,15 @@ defmodule MerklePatriciaTree.CachingTrieTest do
       assert Trie.get_raw_key(disk_trie, "key2") == :not_found
       assert Trie.get_raw_key(disk_trie, "elixir") == :not_found
 
-      CachingTrie.commit!(caching_trie)
+      in_memory_trie_root_hash = caching_trie.in_memory_trie.root_hash
+      committed_trie = CachingTrie.commit!(caching_trie)
 
       assert Trie.get_raw_key(disk_trie, "key1") == {:ok, "value1"}
       assert Trie.get_raw_key(disk_trie, "key2") == {:ok, "value2"}
       assert Trie.get_raw_key(disk_trie, "elixir") == {:ok, "erlang"}
+
+      assert committed_trie.trie.root_hash == in_memory_trie_root_hash
+      assert committed_trie.trie.root_hash == disk_trie.root_hash
     end
   end
 


### PR DESCRIPTION
We weren't updating root hash of permanent storage after committing in-memory trie