### PR TITLE
truncate output for reverted message calls

### DIFF
--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -194,7 +194,7 @@ defmodule EVM.MessageCall do
       if out_size == 0 do
         %{machine_state | last_return_data: output}
       else
-        machine_state = Memory.write(machine_state, out_offset, output)
+        machine_state = Memory.write(machine_state, out_offset, output, out_size)
 
         %{machine_state | last_return_data: output}
       end


### PR DESCRIPTION
We weren't considering `out_size` parameter when writing output from reverted message call. `out_size` defines output size that should be written to memory

fixes https://github.com/mana-ethereum/mana/issues/668