### PR TITLE
Peer mngmt - 2

### DIFF
--- a/apps/ex_wire/config/config.exs
+++ b/apps/ex_wire/config/config.exs
@@ -39,7 +39,6 @@ config :ex_wire,
   discovery: true,
   node_discovery: [
     network_adapter: {ExWire.Adapter.UDP, NetworkClient},
-    # kademlia_process_name: KademliaState,
     supervisor_name: ExWire.NodeDiscoverySupervisor,
     port: 30_304
   ],

--- a/apps/ex_wire/config/config.exs
+++ b/apps/ex_wire/config/config.exs
@@ -39,7 +39,7 @@ config :ex_wire,
   discovery: true,
   node_discovery: [
     network_adapter: {ExWire.Adapter.UDP, NetworkClient},
-    kademlia_process_name: KademliaState,
+    # kademlia_process_name: KademliaState,
     supervisor_name: ExWire.NodeDiscoverySupervisor,
     port: 30_304
   ],

--- a/apps/ex_wire/config/test.exs
+++ b/apps/ex_wire/config/test.exs
@@ -6,7 +6,6 @@ config :ex_wire,
       68, 76, 86, 168, 24, 200, 155, 0, 99, 58, 226, 211, 30>>,
   node_discovery: [
     network_adapter: {ExWire.Adapter.UDP, :test_network_adapter},
-    kademlia_process_name: KademliaState,
     supervisor_name: ExWire.NodeDiscoverySupervisor,
     port: 30_304
   ],

--- a/apps/ex_wire/lib/ex_wire/handler.ex
+++ b/apps/ex_wire/lib/ex_wire/handler.ex
@@ -79,8 +79,8 @@ defmodule ExWire.Handler do
 
       # TODO: Add a `no_response` test case
   """
-  @spec dispatch(Params.t(), Keyword.t()) :: handler_response()
-  def dispatch(params, options \\ []) do
+  @spec dispatch(Params.t()) :: handler_response()
+  def dispatch(params) do
     case @handlers[params.type] do
       nil ->
         :ok = Logger.warn("Message code `#{inspect(params.type, base: :hex)}` not implemented")
@@ -88,7 +88,7 @@ defmodule ExWire.Handler do
 
       mod when is_atom(mod) ->
         Exth.trace(fn -> "Handling #{mod} message from #{inspect(params.remote_host.ip)}" end)
-        apply(mod, :handle, [params, options])
+        apply(mod, :handle, [params])
     end
   end
 end

--- a/apps/ex_wire/lib/ex_wire/handler/find_neighbours.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/find_neighbours.ex
@@ -10,48 +10,8 @@ defmodule ExWire.Handler.FindNeighbours do
   alias ExWire.Message.{FindNeighbours, Neighbours}
   alias ExWire.Struct.Neighbour
 
-  @doc """
-  Handler for a `FindNeighbors` message.
-
-  ## Examples
-
-      iex> {:ok, kademlia_process} = ExWire.FakeKademliaServer.start_link(
-      ...>   [
-      ...>     %ExWire.Kademlia.Node{
-      ...>       public_key: <<1::256>>,
-      ...>       key: <<1::160>>,
-      ...>       endpoint: %ExWire.Struct.Endpoint{
-      ...>         ip: [52, 169, 14, 227],
-      ...>         tcp_port: nil,
-      ...>         udp_port: 30303
-      ...>       }
-      ...>     }
-      ...>   ]
-      ...> )
-      iex> ExWire.Handler.FindNeighbours.handle(%ExWire.Handler.Params{
-      ...>   remote_host: %ExWire.Struct.Endpoint{ip: [1,2,3,4], udp_port: 55},
-      ...>   signature: 2,
-      ...>   recovery_id: 3,
-      ...>   hash: <<5>>,
-      ...>   data: [<<1>>, 2] |> ExRLP.encode,
-      ...>   timestamp: 7,
-      ...> }, kademlia_process_name: kademlia_process)
-      %ExWire.Message.Neighbours{
-        nodes: [
-          %ExWire.Struct.Neighbour{
-            endpoint: %ExWire.Struct.Endpoint{
-              ip: [52, 169, 14, 227],
-              tcp_port: nil,
-              udp_port: 30303
-            },
-            node: <<1::256>>
-          }
-        ],
-        timestamp: 7,
-      }
-  """
   @spec handle(Params.t(), Keyword.t()) :: Handler.handler_response()
-  def handle(params, options \\ []) do
+  def handle(server \\ Server.default_process_name(), params) do
     neighbours = fetch_neighbours(params, options)
 
     %Neighbours{

--- a/apps/ex_wire/lib/ex_wire/handler/find_neighbours.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/find_neighbours.ex
@@ -7,12 +7,11 @@ defmodule ExWire.Handler.FindNeighbours do
   alias ExWire.{Handler, Kademlia}
   alias ExWire.Handler.Params
   alias ExWire.Kademlia.Node
-  alias ExWire.Kademlia.Server
   alias ExWire.Message.{FindNeighbours, Neighbours}
   alias ExWire.Struct.Neighbour
 
   @spec handle(GenServer.server(), Params.t()) :: Handler.handler_response()
-  def handle(server \\ Server.default_process_name(), params) do
+  def handle(server \\ Kademlia.server(), params) do
     neighbours = fetch_neighbours(server, params)
 
     %Neighbours{
@@ -25,7 +24,7 @@ defmodule ExWire.Handler.FindNeighbours do
   Gets the list of neighbors from the Kademlina running gen server.
   """
   @spec fetch_neighbours(GenServer.server(), Params.t()) :: [Neighbour.t()]
-  def fetch_neighbours(server \\ Server.default_process_name(), params) do
+  def fetch_neighbours(server \\ Kademlia.server(), params) do
     neighbours = FindNeighbours.decode(params.data)
 
     nodes_to_neighbours(Kademlia.neighbours(server, neighbours, params.remote_host))

--- a/apps/ex_wire/lib/ex_wire/handler/neighbours.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/neighbours.ex
@@ -32,11 +32,11 @@ defmodule ExWire.Handler.Neighbours do
       ...> })
       :no_response
   """
-  @spec handle(Handler.Params.t(), Keyword.t()) :: Handler.handler_response()
-  def handle(params, options \\ []) do
+  @spec handle(Handler.Params.t()) :: Handler.handler_response()
+  def handle(params) do
     neighbours = Neighbours.decode(params.data)
 
-    Kademlia.handle_neighbours(neighbours, process_name: options[:kademlia_process_name])
+    Kademlia.handle_neighbours(neighbours)
 
     :no_response
   end

--- a/apps/ex_wire/lib/ex_wire/handler/neighbours.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/neighbours.ex
@@ -32,11 +32,11 @@ defmodule ExWire.Handler.Neighbours do
       ...> })
       :no_response
   """
-  @spec handle(Handler.Params.t()) :: Handler.handler_response()
-  def handle(params) do
+  @spec handle(GenServer.server(), Handler.Params.t()) :: Handler.handler_response()
+  def handle(server \\ Kademlia.server(), params) do
     neighbours = Neighbours.decode(params.data)
 
-    Kademlia.handle_neighbours(neighbours)
+    Kademlia.handle_neighbours(server, neighbours)
 
     :no_response
   end

--- a/apps/ex_wire/lib/ex_wire/handler/ping.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/ping.ex
@@ -36,11 +36,11 @@ defmodule ExWire.Handler.Ping do
         }
       }
   """
-  @spec handle(Handler.Params.t()) :: Handler.handler_response()
-  def handle(params) do
+  @spec handle(GenServer.server(), Handler.Params.t()) :: Handler.handler_response()
+  def handle(server \\ Kademlia.server(), params) do
     ping = Ping.decode(params.data)
 
-    Kademlia.handle_ping(params)
+    Kademlia.handle_ping(server, params)
 
     %Pong{
       to: ping.from,

--- a/apps/ex_wire/lib/ex_wire/handler/ping.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/ping.ex
@@ -36,11 +36,11 @@ defmodule ExWire.Handler.Ping do
         }
       }
   """
-  @spec handle(Handler.Params.t(), Keyword.t()) :: Handler.handler_response()
-  def handle(params, options \\ []) do
+  @spec handle(Handler.Params.t()) :: Handler.handler_response()
+  def handle(params) do
     ping = Ping.decode(params.data)
 
-    Kademlia.handle_ping(params, process_name: options[:kademlia_process_name])
+    Kademlia.handle_ping(params)
 
     %Pong{
       to: ping.from,

--- a/apps/ex_wire/lib/ex_wire/handler/pong.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/pong.ex
@@ -22,11 +22,11 @@ defmodule ExWire.Handler.Pong do
       ...> })
       :no_response
   """
-  @spec handle(Handler.Params.t(), Keyword.t()) :: Handler.handler_response()
-  def handle(params, options \\ []) do
+  @spec handle(Handler.Params.t()) :: Handler.handler_response()
+  def handle(params) do
     pong = Pong.decode(params.data)
 
-    Kademlia.handle_pong(pong, process_name: options[:kademlia_process_name])
+    Kademlia.handle_pong(pong)
 
     :no_response
   end

--- a/apps/ex_wire/lib/ex_wire/handler/pong.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/pong.ex
@@ -22,11 +22,11 @@ defmodule ExWire.Handler.Pong do
       ...> })
       :no_response
   """
-  @spec handle(Handler.Params.t()) :: Handler.handler_response()
-  def handle(params) do
+  @spec handle(GenServer.server(), Handler.Params.t()) :: Handler.handler_response()
+  def handle(server \\ Kademlia.server(), params) do
     pong = Pong.decode(params.data)
 
-    Kademlia.handle_pong(pong)
+    Kademlia.handle_pong(server, pong)
 
     :no_response
   end

--- a/apps/ex_wire/lib/ex_wire/kademlia.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia.ex
@@ -8,11 +8,15 @@ defmodule ExWire.Kademlia do
   alias ExWire.Message.{FindNeighbours, Neighbours, Pong}
   alias ExWire.Struct.Endpoint
 
+  @server Server.name()
+  @spec server() :: Server.name()
+  def server, do: @server
+
   @doc """
   Adds new node to routing table.
   """
   @spec refresh_node(GenServer.server(), Node.t()) :: :ok
-  def refresh_node(server \\ Server.default_process_name(), peer = %Node{}) do
+  def refresh_node(server \\ Server.name(), peer = %Node{}) do
     GenServer.cast(server, {:refresh_node, peer})
   end
 
@@ -20,7 +24,7 @@ defmodule ExWire.Kademlia do
   Handles pong message (adds a node to routing table etc).
   """
   @spec handle_pong(Pong.t(), Keyword.t()) :: :ok
-  def handle_pong(server \\ Server.default_process_name(), pong = %Pong{}) do
+  def handle_pong(server \\ Server.name(), pong = %Pong{}) do
     GenServer.cast(server, {:handle_pong, pong})
   end
 
@@ -28,7 +32,7 @@ defmodule ExWire.Kademlia do
   Handles ping message (by adding a node to routing table etc).
   """
   @spec handle_ping(Params.t(), Keyword.t()) :: :ok
-  def handle_ping(server \\ Server.default_process_name(), params = %Params{}) do
+  def handle_ping(server \\ Server.name(), params = %Params{}) do
     GenServer.cast(server, {:handle_ping, params})
   end
 
@@ -36,7 +40,7 @@ defmodule ExWire.Kademlia do
   Sends ping to a node saving it to expected pongs.
   """
   @spec ping(Node.t(), Keyword.t()) :: :ok
-  def ping(server \\ Server.default_process_name(), node = %Node{}) do
+  def ping(server \\ Server.name(), node = %Node{}) do
     GenServer.cast(server, {:ping, node})
   end
 
@@ -44,7 +48,7 @@ defmodule ExWire.Kademlia do
   Returns current routing table.
   """
   @spec routing_table() :: RoutingTable.t()
-  def routing_table(server \\ Server.default_process_name()) do
+  def routing_table(server \\ Server.name()) do
     GenServer.call(server, :routing_table)
   end
 
@@ -52,7 +56,7 @@ defmodule ExWire.Kademlia do
   Returns neighbours of specified node.
   """
   @spec neighbours(FindNeighbours.t(), Endpoint.t(), Keyword.t()) :: [Node.t()]
-  def neighbours(server \\ Server.default_process_name(), find_neighbours, endpoint) do
+  def neighbours(server \\ Server.name(), find_neighbours, endpoint) do
     GenServer.call(server, {:neighbours, find_neighbours, endpoint})
   end
 
@@ -60,7 +64,7 @@ defmodule ExWire.Kademlia do
   Receives neighbours request and ping each of them if request is not expired.
   """
   @spec handle_neighbours(Neighbours.t(), Keyword.t()) :: :ok
-  def handle_neighbours(server \\ Server.default_process_name(), neighbours) do
+  def handle_neighbours(server \\ Server.name(), neighbours) do
     GenServer.cast(server, {:handle_neighbours, neighbours})
   end
 end

--- a/apps/ex_wire/lib/ex_wire/kademlia.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia.ex
@@ -63,9 +63,4 @@ defmodule ExWire.Kademlia do
   def handle_neighbours(server \\ Server.default_process_name(), neighbours) do
     GenServer.cast(server, {:handle_neighbours, neighbours})
   end
-
-  # @spec process_name(Keyword.t()) :: atom()
-  # defp process_name(opts) do
-  #   opts[:process_name]
-  # end
 end

--- a/apps/ex_wire/lib/ex_wire/kademlia.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia.ex
@@ -9,7 +9,7 @@ defmodule ExWire.Kademlia do
   alias ExWire.Struct.Endpoint
 
   @server Server.name()
-  @spec server() :: Server.name()
+  @spec server() :: unquote(Server.name())
   def server, do: @server
 
   @doc """
@@ -23,7 +23,7 @@ defmodule ExWire.Kademlia do
   @doc """
   Handles pong message (adds a node to routing table etc).
   """
-  @spec handle_pong(Pong.t(), Keyword.t()) :: :ok
+  @spec handle_pong(GenServer.server(), Pong.t()) :: :ok
   def handle_pong(server \\ Server.name(), pong = %Pong{}) do
     GenServer.cast(server, {:handle_pong, pong})
   end
@@ -31,7 +31,7 @@ defmodule ExWire.Kademlia do
   @doc """
   Handles ping message (by adding a node to routing table etc).
   """
-  @spec handle_ping(Params.t(), Keyword.t()) :: :ok
+  @spec handle_ping(GenServer.server(), Params.t()) :: :ok
   def handle_ping(server \\ Server.name(), params = %Params{}) do
     GenServer.cast(server, {:handle_ping, params})
   end
@@ -39,7 +39,7 @@ defmodule ExWire.Kademlia do
   @doc """
   Sends ping to a node saving it to expected pongs.
   """
-  @spec ping(Node.t(), Keyword.t()) :: :ok
+  @spec ping(GenServer.server(), Node.t()) :: :ok
   def ping(server \\ Server.name(), node = %Node{}) do
     GenServer.cast(server, {:ping, node})
   end
@@ -55,7 +55,7 @@ defmodule ExWire.Kademlia do
   @doc """
   Returns neighbours of specified node.
   """
-  @spec neighbours(FindNeighbours.t(), Endpoint.t(), Keyword.t()) :: [Node.t()]
+  @spec neighbours(GenServer.server(), FindNeighbours.t(), Endpoint.t()) :: [Node.t()]
   def neighbours(server \\ Server.name(), find_neighbours, endpoint) do
     GenServer.call(server, {:neighbours, find_neighbours, endpoint})
   end
@@ -63,7 +63,7 @@ defmodule ExWire.Kademlia do
   @doc """
   Receives neighbours request and ping each of them if request is not expired.
   """
-  @spec handle_neighbours(Neighbours.t(), Keyword.t()) :: :ok
+  @spec handle_neighbours(GenServer.server(), Neighbours.t()) :: :ok
   def handle_neighbours(server \\ Server.name(), neighbours) do
     GenServer.cast(server, {:handle_neighbours, neighbours})
   end

--- a/apps/ex_wire/lib/ex_wire/kademlia.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia.ex
@@ -11,75 +11,61 @@ defmodule ExWire.Kademlia do
   @doc """
   Adds new node to routing table.
   """
-  @spec refresh_node(Node.t(), Keyword.t()) :: :ok
-  def refresh_node(peer = %Node{}, opts \\ []) do
-    opts
-    |> process_name()
-    |> GenServer.cast({:refresh_node, peer})
+  @spec refresh_node(GenServer.server(), Node.t()) :: :ok
+  def refresh_node(server \\ Server.default_process_name(), peer = %Node{}) do
+    GenServer.cast(server, {:refresh_node, peer})
   end
 
   @doc """
   Handles pong message (adds a node to routing table etc).
   """
   @spec handle_pong(Pong.t(), Keyword.t()) :: :ok
-  def handle_pong(pong = %Pong{}, opts \\ []) do
-    opts
-    |> process_name()
-    |> GenServer.cast({:handle_pong, pong})
+  def handle_pong(server \\ Server.default_process_name(), pong = %Pong{}) do
+    GenServer.cast(server, {:handle_pong, pong})
   end
 
   @doc """
   Handles ping message (by adding a node to routing table etc).
   """
   @spec handle_ping(Params.t(), Keyword.t()) :: :ok
-  def handle_ping(params = %Params{}, opts \\ []) do
-    opts
-    |> process_name()
-    |> GenServer.cast({:handle_ping, params})
+  def handle_ping(server \\ Server.default_process_name(), params = %Params{}) do
+    GenServer.cast(server, {:handle_ping, params})
   end
 
   @doc """
   Sends ping to a node saving it to expected pongs.
   """
   @spec ping(Node.t(), Keyword.t()) :: :ok
-  def ping(node = %Node{}, opts \\ []) do
-    opts
-    |> process_name()
-    |> GenServer.cast({:ping, node})
+  def ping(server \\ Server.default_process_name(), node = %Node{}) do
+    GenServer.cast(server, {:ping, node})
   end
 
   @doc """
   Returns current routing table.
   """
-  @spec routing_table(Keyword.t()) :: RoutingTable.t()
-  def routing_table(opts \\ []) do
-    opts
-    |> process_name()
-    |> GenServer.call(:routing_table)
+  @spec routing_table() :: RoutingTable.t()
+  def routing_table(server \\ Server.default_process_name()) do
+    GenServer.call(server, :routing_table)
   end
 
   @doc """
   Returns neighbours of specified node.
   """
   @spec neighbours(FindNeighbours.t(), Endpoint.t(), Keyword.t()) :: [Node.t()]
-  def neighbours(find_neighbours, endpoint, opts \\ []) do
-    opts
-    |> process_name()
-    |> GenServer.call({:neighbours, find_neighbours, endpoint})
+  def neighbours(server \\ Server.default_process_name(), find_neighbours, endpoint) do
+    GenServer.call(server, {:neighbours, find_neighbours, endpoint})
   end
 
   @doc """
   Receives neighbours request and ping each of them if request is not expired.
   """
   @spec handle_neighbours(Neighbours.t(), Keyword.t()) :: :ok
-  def handle_neighbours(neighbours, opts \\ []) do
-    opts
-    |> process_name()
-    |> GenServer.cast({:handle_neighbours, neighbours})
+  def handle_neighbours(server \\ Server.default_process_name(), neighbours) do
+    GenServer.cast(server, {:handle_neighbours, neighbours})
   end
 
-  @spec process_name(Keyword.t()) :: atom()
-  defp process_name(opts) do
-    opts[:process_name] || Server.default_process_name()
-  end
+  # @spec process_name(Keyword.t()) :: atom()
+  # defp process_name(opts) do
+  #   opts[:process_name]
+  # end
 end

--- a/apps/ex_wire/lib/ex_wire/kademlia/server.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/server.ex
@@ -11,7 +11,7 @@ defmodule ExWire.Kademlia.Server do
           ignore_pongs: boolean()
         }
 
-  @default_process_name KademliaState
+  @default_process_name __MODULE__
 
   @max_discovery_rounds 7
 

--- a/apps/ex_wire/lib/ex_wire/kademlia/server.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/server.ex
@@ -11,8 +11,6 @@ defmodule ExWire.Kademlia.Server do
           ignore_pongs: boolean()
         }
 
-  @default_process_name __MODULE__
-
   @max_discovery_rounds 7
 
   # 5s
@@ -21,7 +19,8 @@ defmodule ExWire.Kademlia.Server do
   # 10s
   @pong_cleanup_period 10_000
 
-  @spec default_process_name() :: KademliaState
+  @default_process_name __MODULE__
+  @spec default_process_name() :: unquote(@default_process_name)
   def default_process_name, do: @default_process_name
 
   @spec start_link(Keyword.t()) :: GenServer.on_start()

--- a/apps/ex_wire/lib/ex_wire/kademlia/server.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/server.ex
@@ -19,13 +19,13 @@ defmodule ExWire.Kademlia.Server do
   # 10s
   @pong_cleanup_period 10_000
 
-  @default_process_name __MODULE__
-  @spec default_process_name() :: unquote(@default_process_name)
-  def default_process_name, do: @default_process_name
+  @name __MODULE__
+  @spec name() :: unquote(@name)
+  def name, do: @name
 
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(params) do
-    name = Keyword.get(params, :name, @default_process_name)
+    name = Keyword.get(params, :name, @name)
     network_client_name = Keyword.fetch!(params, :network_client_name)
     current_node = Keyword.fetch!(params, :current_node)
     nodes = Keyword.get(params, :nodes, [])

--- a/apps/ex_wire/lib/ex_wire/network.ex
+++ b/apps/ex_wire/lib/ex_wire/network.ex
@@ -104,7 +104,7 @@ defmodule ExWire.Network do
       timestamp: timestamp
     }
 
-    case Handler.dispatch(params, options) do
+    case Handler.dispatch(params) do
       :not_implemented ->
         :no_action
 

--- a/apps/ex_wire/lib/ex_wire/network.ex
+++ b/apps/ex_wire/lib/ex_wire/network.ex
@@ -19,13 +19,17 @@ defmodule ExWire.Network do
     defstruct data: nil,
               server_pid: nil,
               remote_host: nil,
-              timestamp: nil
+              timestamp: nil,
+              # Like kademlia
+              handler_pid: nil
 
     @type t :: %__MODULE__{
             data: binary(),
             server_pid: pid(),
             remote_host: Endpoint.t(),
-            timestamp: integer()
+            timestamp: integer(),
+            # kademlia pid server
+            handler_pid: GenServer.server() | nil
           }
   end
 
@@ -42,7 +46,7 @@ defmodule ExWire.Network do
   We'll first validate the message, and then pass it to
   the appropriate handler.
   """
-  @spec receive(InboundMessage.t(), Keyword.t()) :: handler_action()
+  @spec receive(InboundMessage.t()) :: handler_action()
   def receive(
         inbound_message = %InboundMessage{
           data: data,
@@ -90,7 +94,8 @@ defmodule ExWire.Network do
           >>,
           server_pid: server_pid,
           remote_host: remote_host,
-          timestamp: timestamp
+          timestamp: timestamp,
+          handler_pid: handler_pid
         },
         options \\ []
       ) do
@@ -101,7 +106,8 @@ defmodule ExWire.Network do
       hash: hash,
       data: data,
       type: type,
-      timestamp: timestamp
+      timestamp: timestamp,
+      handler_pid: handler_pid
     }
 
     case Handler.dispatch(params) do

--- a/apps/ex_wire/lib/ex_wire/node_discovery_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/node_discovery_supervisor.ex
@@ -19,7 +19,6 @@ defmodule ExWire.NodeDiscoverySupervisor do
   end
 
   def init(params) do
-    kademlia_name = Keyword.get(params, :kademlia_process_name, KademliaState)
     {udp_module, udp_process_name} = ExWire.Config.udp_network_adapter(params)
     port = ExWire.Config.listen_port(params)
 
@@ -36,7 +35,6 @@ defmodule ExWire.NodeDiscoverySupervisor do
           :start_link,
           [
             [
-              name: kademlia_name,
               current_node: current_node(params),
               network_client_name: udp_process_name,
               nodes: bootnodes
@@ -50,7 +48,7 @@ defmodule ExWire.NodeDiscoverySupervisor do
           {udp_module, :start_link,
            [
              udp_process_name,
-             {Network, [kademlia_process_name: kademlia_name]},
+             {Network, [kademlia_process_name: ExWire.Kademlia.Server]},
              port
            ]}
       }

--- a/apps/ex_wire/test/ex_wire/ex_wire_test.exs
+++ b/apps/ex_wire/test/ex_wire/ex_wire_test.exs
@@ -78,8 +78,7 @@ defmodule ExWireTest do
 
     params = %{data: FindNeighbours.encode(find_neighbours), remote_host: %Endpoint{}}
 
-    neighbours =
-      FindNeighboursHandler.fetch_neighbours(params, kademlia_process_name: kademlia_process)
+    neighbours = FindNeighboursHandler.fetch_neighbours(kademlia_process, params)
 
     response = %Neighbours{
       nodes: neighbours,

--- a/apps/ex_wire/test/ex_wire/handler/find_neighbours_test.exs
+++ b/apps/ex_wire/test/ex_wire/handler/find_neighbours_test.exs
@@ -1,4 +1,45 @@
 defmodule ExWire.Handler.FindNeighboursTest do
   use ExUnit.Case, async: true
   doctest ExWire.Handler.FindNeighbours
+
+  test "handler for a `FindNeighbors` message" do
+    {:ok, kademlia_process} =
+      ExWire.FakeKademliaServer.start_link([
+        %ExWire.Kademlia.Node{
+          public_key: <<1::256>>,
+          key: <<1::160>>,
+          endpoint: %ExWire.Struct.Endpoint{
+            ip: [52, 169, 14, 227],
+            tcp_port: nil,
+            udp_port: 30303
+          }
+        }
+      ])
+
+    ExWire.Handler.FindNeighbours.handle(
+      %ExWire.Handler.Params{
+        remote_host: %ExWire.Struct.Endpoint{ip: [1, 2, 3, 4], udp_port: 55},
+        signature: 2,
+        recovery_id: 3,
+        hash: <<5>>,
+        data: [<<1>>, 2] |> ExRLP.encode(),
+        timestamp: 7
+      },
+      kademlia_process_name: kademlia_process
+    )
+
+    %ExWire.Message.Neighbours{
+      nodes: [
+        %ExWire.Struct.Neighbour{
+          endpoint: %ExWire.Struct.Endpoint{
+            ip: [52, 169, 14, 227],
+            tcp_port: nil,
+            udp_port: 30303
+          },
+          node: <<1::256>>
+        }
+      ],
+      timestamp: 7
+    }
+  end
 end

--- a/apps/ex_wire/test/ex_wire/handler/find_neighbours_test.exs
+++ b/apps/ex_wire/test/ex_wire/handler/find_neighbours_test.exs
@@ -11,12 +11,13 @@ defmodule ExWire.Handler.FindNeighboursTest do
           endpoint: %ExWire.Struct.Endpoint{
             ip: [52, 169, 14, 227],
             tcp_port: nil,
-            udp_port: 30303
+            udp_port: 30_303
           }
         }
       ])
 
     ExWire.Handler.FindNeighbours.handle(
+      kademlia_process,
       %ExWire.Handler.Params{
         remote_host: %ExWire.Struct.Endpoint{ip: [1, 2, 3, 4], udp_port: 55},
         signature: 2,
@@ -24,8 +25,7 @@ defmodule ExWire.Handler.FindNeighboursTest do
         hash: <<5>>,
         data: [<<1>>, 2] |> ExRLP.encode(),
         timestamp: 7
-      },
-      kademlia_process_name: kademlia_process
+      }
     )
 
     %ExWire.Message.Neighbours{
@@ -34,7 +34,7 @@ defmodule ExWire.Handler.FindNeighboursTest do
           endpoint: %ExWire.Struct.Endpoint{
             ip: [52, 169, 14, 227],
             tcp_port: nil,
-            udp_port: 30303
+            udp_port: 30_303
           },
           node: <<1::256>>
         }

--- a/apps/ex_wire/test/support/ex_wire/adapter/test.ex
+++ b/apps/ex_wire/test/support/ex_wire/adapter/test.ex
@@ -36,15 +36,13 @@ defmodule ExWire.Adapter.Test do
          }, options},
         state = %{network: network}
       ) do
-    network.receive(
-      %ExWire.Network.InboundMessage{
-        data: data,
-        server_pid: self(),
-        remote_host: remote_host,
-        timestamp: timestamp
-      },
-      options
-    )
+    network.receive(%ExWire.Network.InboundMessage{
+      data: data,
+      server_pid: self(),
+      remote_host: remote_host,
+      timestamp: timestamp,
+      handler_pid: Keyword.get(options, :kademlia_process_name)
+    })
 
     {:noreply, state}
   end


### PR DESCRIPTION
- Removing configurable process names (?).
- Spreading process state over modules.
- Removed keyword type server name passing

An alternative to #680 