### PR TITLE
Complete Ethash implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,27 @@ jobs:
           command: mix cmd --app blockchain mix test --exclude test --include Constantinople
           no_output_timeout: 2400
 
+  Ethash:
+    docker:
+      - image: circleci/elixir:1.7.4
+        environment:
+          MIX_ENV: test
+
+    working_directory: ~/app
+
+    steps:
+      - attach_workspace:
+           at: .
+
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+
+      - restore_cache:
+          keys:
+            - v13-mix-cache-{{ checksum "mix.lock" }}
+
+      - run: mix cmd --app blockchain mix test --exclude test --include Ethash
+
   dialyzer:
     docker:
       # Ensure .tool-versions matches
@@ -391,6 +412,8 @@ workflows:
       - Byzantium:
           requires: [build]
       - Constantinople:
+          requires: [build]
+      - Ethash:
           requires: [build]
       - network:
           requires: [build]

--- a/apps/blockchain/lib/blockchain/ethash/rand_memo_hash.ex
+++ b/apps/blockchain/lib/blockchain/ethash/rand_memo_hash.ex
@@ -49,7 +49,7 @@ defmodule Blockchain.Ethash.RandMemoHash do
   defp second_index(i, n, cache) do
     cache_element = Map.fetch!(cache, i)
 
-    <<header::size(8), _rest::binary>> = cache_element
+    <<header::little-integer-size(32), _rest::binary>> = cache_element
 
     Integer.mod(header, n)
   end


### PR DESCRIPTION
This closes https://github.com/mana-ethereum/mana/issues/541

Description
===========

This commit fixes a few issues that we encountered with the Ethash implementation. The issues were raised when trying to pass the PoW Ethereum common tests.

Some of the issues fixed:

- Use 32 bit unsigned integer in RandMemoHash algorithm (generates correct cache)

- Use correct 32 bit unsigned integer in mix initialization

Testing
-------

Note that we only test the light version of the ethash algorithm. The full version simply generates the full dataset prior to calculating the algorithm. The light version lazily generates the dataset items it requires.

We only test the light version because of time constraints. The dataset generation for the PoW common tests takes a long time, so we do not want to introduce that into CI. Nevertheless, we add some concurrency to the dataset generation since it should speed up the generation of the full dataset. 

When validating block headers or mining, we would likely store the cache and the dataset in memory since it only changes every epoch.