### PR TITLE
Wire Sub-Protocol Capability Configuration

### DIFF
--- a/apps/ex_wire/lib/ex_wire/dev_p2p.ex
+++ b/apps/ex_wire/lib/ex_wire/dev_p2p.ex
@@ -8,6 +8,7 @@ defmodule ExWire.DEVp2p do
 
   alias ExWire.Config
   alias ExWire.DEVp2p.Session
+  alias ExWire.Packet.Capability.Mana
   alias ExWire.Packet.Protocol.Hello
 
   @doc """
@@ -32,7 +33,7 @@ defmodule ExWire.DEVp2p do
     %Hello{
       p2p_version: Config.p2p_version(),
       client_id: Config.client_id(),
-      caps: Config.caps(),
+      caps: Mana.get_our_capabilities(),
       listen_port: Config.listen_port(),
       node_id: Config.node_id()
     }

--- a/apps/ex_wire/lib/ex_wire/packet/capability/eth.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/eth.ex
@@ -1,8 +1,11 @@
 defmodule ExWire.Packet.Capability.Eth do
+  alias ExWire.Config
   alias ExWire.Packet.Capability
   alias ExWire.Packet.Capability.Eth
 
   @behaviour Capability
+
+  @name "eth"
 
   @version_to_packet_types %{
     62 => [
@@ -17,11 +20,20 @@ defmodule ExWire.Packet.Capability.Eth do
     ]
   }
 
-  @supported_versions Map.keys(@version_to_packet_types)
+  @supported_versions MapSet.to_list(
+                        MapSet.intersection(
+                          MapSet.new(Map.keys(@version_to_packet_types)),
+                          MapSet.new(
+                            Config.caps()
+                            |> Enum.filter(fn cap -> cap.name == @name end)
+                            |> Enum.map(fn cap -> cap.version end)
+                          )
+                        )
+                      )
 
   @impl true
   def get_name() do
-    "eth"
+    @name
   end
 
   @impl true

--- a/apps/ex_wire/lib/ex_wire/packet/capability/eth.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/eth.ex
@@ -20,16 +20,14 @@ defmodule ExWire.Packet.Capability.Eth do
     ]
   }
 
-  @supported_versions MapSet.to_list(
-                        MapSet.intersection(
-                          MapSet.new(Map.keys(@version_to_packet_types)),
-                          MapSet.new(
-                            Config.caps()
-                            |> Enum.filter(fn cap -> cap.name == @name end)
-                            |> Enum.map(fn cap -> cap.version end)
-                          )
-                        )
-                      )
+  @available_versions Map.keys(@version_to_packet_types)
+  @configured_versions Config.caps()
+                       |> Enum.filter(fn cap -> cap.name == @name end)
+                       |> Enum.map(fn cap -> cap.version end)
+
+  @supported_versions Enum.filter(@available_versions, fn el ->
+                        Enum.member?(@configured_versions, el)
+                      end)
 
   @impl true
   def get_name() do

--- a/apps/ex_wire/lib/ex_wire/packet/capability/mana.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/mana.ex
@@ -9,6 +9,7 @@ defmodule ExWire.Packet.Capability.Mana do
   @our_capabilities @our_capabilities_map
                     |> Enum.map(fn {name, mod} ->
                       versions = apply(mod, :get_supported_versions, [])
+
                       versions
                       |> Enum.map(fn version -> Capability.new({name, version}) end)
                     end)

--- a/apps/ex_wire/lib/ex_wire/packet/capability/mana.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/mana.ex
@@ -1,11 +1,25 @@
 defmodule ExWire.Packet.Capability.Mana do
+  alias ExWire.Packet.Capability
   alias ExWire.Packet.Capability.Eth
 
-  @our_capabilities %{
+  @our_capabilities_map %{
     Eth.get_name() => Eth
   }
 
+  @our_capabilities @our_capabilities_map
+                    |> Enum.map(fn {name, mod} ->
+                      versions = apply(mod, :get_supported_versions, [])
+                      versions
+                      |> Enum.map(fn version -> Capability.new({name, version}) end)
+                    end)
+                    |> List.flatten()
+
   def get_our_capabilities_map() do
+    @our_capabilities_map
+  end
+
+  @spec get_our_capabilities() :: [Capability.t()]
+  def get_our_capabilities() do
     @our_capabilities
   end
 end


### PR DESCRIPTION
Fixes an issue where we blindly pull our capabilities list from config, instead starting with the capabilities that we _can_ support and paring them down based on what is configured.

Also adds logic to `ExWire.Packet.Capability.Eth.Hello` to only recommend activating peers if they have shared capabilities.