### PR TITLE
Add Block `with_hash` and `fetch_block_hash` helpers

### DIFF
--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -168,6 +168,70 @@ defmodule Blockchain.Block do
   def hash(block), do: Header.hash(block.header)
 
   @doc """
+  Fetches the block hash for a block, either by calculating the block hash
+  based on the block data, or returning the block hash from the block's struct.
+
+  ## Examples
+
+      iex> %Blockchain.Block{header: %Block.Header{number: 5, parent_hash: <<1, 2, 3>>, beneficiary: <<2, 3, 4>>, difficulty: 100, timestamp: 11, mix_hash: <<1>>, nonce: <<2>>}}
+      ...> |> Blockchain.Block.fetch_block_hash()
+      <<78, 28, 127, 10, 192, 253, 127, 239, 254, 179, 39, 34, 245, 44, 152, 98, 128, 71, 238, 155, 100, 161, 199, 71, 243, 223, 172, 191, 74, 99, 128, 63>>
+
+      iex> %Blockchain.Block{block_hash: <<5::256>>, header: %Block.Header{number: 5, parent_hash: <<1, 2, 3>>, beneficiary: <<2, 3, 4>>, difficulty: 100, timestamp: 11, mix_hash: <<1>>, nonce: <<2>>}}
+      ...> |> Blockchain.Block.fetch_block_hash()
+      <<5::256>>
+  """
+  @spec fetch_block_hash(t()) :: EVM.hash()
+  def fetch_block_hash(block) do
+    case block.block_hash do
+      nil -> hash(block)
+      block_hash -> block_hash
+    end
+  end
+
+  @doc """
+  If a block already has a hash, returns the same unchanged, but if the block
+  hash has not yet been calculated, returns the block with the block hash
+  stored in the struct.
+
+  ## Examples
+
+      iex> %Blockchain.Block{header: %Block.Header{number: 5, parent_hash: <<1, 2, 3>>, beneficiary: <<2, 3, 4>>, difficulty: 100, timestamp: 11, mix_hash: <<1>>, nonce: <<2>>}}
+      ...> |> Blockchain.Block.with_hash()
+      %Blockchain.Block{
+        block_hash: <<78, 28, 127, 10, 192, 253, 127, 239, 254, 179, 39, 34, 245, 44, 152, 98, 128, 71, 238, 155, 100, 161, 199, 71, 243, 223, 172, 191, 74, 99, 128, 63>>,
+        header: %Block.Header{
+          number: 5,
+          parent_hash: <<1, 2, 3>>,
+          beneficiary: <<2, 3, 4>>,
+          difficulty: 100,
+          timestamp: 11,
+          mix_hash: <<1>>,
+          nonce: <<2>>
+        }
+      }
+
+      iex> %Blockchain.Block{block_hash: <<5::256>>, header: %Block.Header{number: 5, parent_hash: <<1, 2, 3>>, beneficiary: <<2, 3, 4>>, difficulty: 100, timestamp: 11, mix_hash: <<1>>, nonce: <<2>>}}
+      ...> |> Blockchain.Block.with_hash()
+      %Blockchain.Block{
+        block_hash: <<5::256>>,
+        header: %Block.Header{
+          number: 5,
+          parent_hash: <<1, 2, 3>>,
+          beneficiary: <<2, 3, 4>>,
+          difficulty: 100,
+          timestamp: 11,
+          mix_hash: <<1>>,
+          nonce: <<2>>
+        }
+      }
+  """
+  @spec with_hash(t()) :: t()
+  def with_hash(block) do
+    %{block | block_hash: fetch_block_hash(block)}
+  end
+
+  @doc """
   Stores a given block in the database and returns the block hash.
 
   This should be used if we ever want to retrieve that block in


### PR DESCRIPTION
The Block struct contains information about a block, and the block hash is a very important and commonly used field. However, as it's based on the other data in a block (which may have been added peicemeal), it's not obvious when we should calculate the blockhash (though it's very obvious when we need it). This makes block_hash a good candidate for lazy evaluation (calculate the value when it's needed, but keep it around for later uses). We standardize this by adding two functions `Block.with_hash` and `Block.fetch_block_hash` which handle reading the block hash if it exists and calculating it if it doesn't. As Elixir values are immutable, we don't have a good way of forcing downstream code to continue to pass around the struct with the calculated value, but we can try our best that it does.