### PR TITLE
count bits only for 256 bit numbers

### DIFF
--- a/apps/evm/lib/evm/builtin/mod_exp.ex
+++ b/apps/evm/lib/evm/builtin/mod_exp.ex
@@ -92,10 +92,18 @@ defmodule EVM.Builtin.ModExp do
           integer()
   defp e_length_prime(e_length, e, _) when e == 0 and e_length <= 32, do: 0
 
-  defp e_length_prime(e_length, e, _) when e_length <= 32 do
-    bin_e = :binary.encode_unsigned(e)
+  defp e_length_prime(e_length, e, _) when e_length < 32 do
+    e_bin = :binary.encode_unsigned(e)
+    8 * (e_length - 32) + highest_bit(e_bin, e_length)
+  end
 
-    8 * (e_length - 32) + highest_bit(bin_e, e_length)
+  defp e_length_prime(e_length, e, _) when e_length == 32 do
+    e_bin =
+      e
+      |> :binary.encode_unsigned()
+      |> EVM.Helpers.left_pad_bytes()
+
+    8 * (e_length - 32) + highest_bit(e_bin, e_length)
   end
 
   defp e_length_prime(e_length, _e, {b_length, data}) do
@@ -115,14 +123,9 @@ defmodule EVM.Builtin.ModExp do
 
   defp highest_bit(binary_number, _) do
     bit_list = for <<b::1 <- binary_number>>, do: b
-    bit_count = Enum.count(bit_list)
 
-    if bit_count < 256 do
-      binary_number
-      |> :binary.decode_unsigned()
-      |> :math.log2()
-      |> Float.floor()
-      |> round()
+    if List.first(bit_list) == 1 do
+      255
     else
       index = Enum.find_index(bit_list, fn x -> x != 0 end)
 

--- a/apps/evm/lib/evm/builtin/mod_exp.ex
+++ b/apps/evm/lib/evm/builtin/mod_exp.ex
@@ -114,15 +114,16 @@ defmodule EVM.Builtin.ModExp do
   defp highest_bit(_, 0), do: 0
 
   defp highest_bit(binary_number, _) do
-    number = :binary.decode_unsigned(binary_number)
+    bit_list = for <<b::1 <- binary_number>>, do: b
+    bit_count = Enum.count(bit_list)
 
-    if number < 256 do
-      number
+    if bit_count < 256 do
+      binary_number
+      |> :binary.decode_unsigned()
       |> :math.log2()
       |> Float.floor()
       |> round()
     else
-      bit_list = for <<b::1 <- binary_number>>, do: b
       index = Enum.find_index(bit_list, fn x -> x != 0 end)
 
       index = index || 0

--- a/apps/evm/test/evm/builtin/mod_exp_test.exs
+++ b/apps/evm/test/evm/builtin/mod_exp_test.exs
@@ -42,4 +42,24 @@ defmodule EVM.Builtin.ModExpTest do
              <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                0, 0, 0, 10>>
   end
+
+  # https://github.com/mana-ethereum/mana/issues/696
+  test "calculated mod_exp (block #4_177_934)" do
+    data =
+      "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000998c4052932635000000000000000000000000000000000000000000048a1b4aab9b9331498981000000000000000000000000000000000000000000000000000000000000000b"
+      |> Base.decode16!(case: :lower)
+
+    available_gas = 1_000_000
+
+    exec_env = %EVM.ExecEnv{data: data, config: EVM.Configuration.Byzantium.new()}
+    {result_gas, _, _, output} = ModExp.exec(available_gas, exec_env)
+
+    cost = available_gas - result_gas
+
+    assert cost == 4_198
+
+    assert output ==
+             <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               0, 0, 0, 9>>
+  end
 end


### PR DESCRIPTION
Most languages (Rust, Java etc) have builtin functions that calculate leading zeroes. Unfortunately Elixir doesn't have them. So we're using what we have.

we need to pad 32-byte numbers with zeroes in its binary representation.


fixes https://github.com/mana-ethereum/mana/issues/696