### PR TITLE
fix block hash key

### DIFF
--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -294,7 +294,7 @@ defmodule Blockchain.Block do
   end
 
   defp get_block_hash_key(block_number) do
-    "hash_for_#{block_number}}"
+    "hash_for_#{block_number}"
   end
 
   @doc """


### PR DESCRIPTION
while working on https://github.com/mana-ethereum/mana/pull/677 I found that block hash keys are generated with `}` at the end

Example
`"hash_for_1}"`