### PR TITLE
getting p2p version and caps into the peer

### DIFF
--- a/apps/ex_wire/config/dev.exs
+++ b/apps/ex_wire/config/dev.exs
@@ -1,8 +1,8 @@
 use Mix.Config
 
 config :ex_wire,
-  sync: true,
-  discovery: true,
+  sync: false,
+  discovery: false,
   private_key:
     <<10, 122, 189, 137, 166, 190, 127, 238, 229, 16, 211, 182, 104, 78, 138, 37, 146, 116, 90,
       68, 76, 86, 168, 24, 200, 155, 0, 99, 58, 226, 211, 30>>,
@@ -11,5 +11,4 @@ config :ex_wire,
     kademlia_process_name: KademliaState,
     supervisor_name: ExWire.NodeDiscoverySupervisor,
     port: 30_304
-  ],
-  chain: :ropsten
+  ]

--- a/apps/ex_wire/config/dev.exs
+++ b/apps/ex_wire/config/dev.exs
@@ -1,8 +1,8 @@
 use Mix.Config
 
 config :ex_wire,
-  sync: false,
-  discovery: false,
+  sync: true,
+  discovery: true,
   private_key:
     <<10, 122, 189, 137, 166, 190, 127, 238, 229, 16, 211, 182, 104, 78, 138, 37, 146, 116, 90,
       68, 76, 86, 168, 24, 200, 155, 0, 99, 58, 226, 211, 30>>,
@@ -11,4 +11,5 @@ config :ex_wire,
     kademlia_process_name: KademliaState,
     supervisor_name: ExWire.NodeDiscoverySupervisor,
     port: 30_304
-  ]
+  ],
+  chain: :ropsten

--- a/apps/ex_wire/lib/ex_wire/connection_observer.ex
+++ b/apps/ex_wire/lib/ex_wire/connection_observer.ex
@@ -51,7 +51,6 @@ defmodule ExWire.ConnectionObserver do
         {:EXIT, _pid, {_, %Connection{is_outbound: false, peer: peer}}},
         state
       ) do
-    IO.inspect(state.inbound_peers)
     {:noreply, %{state | inbound_peers: MapSet.put(state.inbound_peers, peer)}}
   end
 

--- a/apps/ex_wire/lib/ex_wire/connection_observer.ex
+++ b/apps/ex_wire/lib/ex_wire/connection_observer.ex
@@ -42,6 +42,7 @@ defmodule ExWire.ConnectionObserver do
         state
       ) do
     :ok = start_new_outbound_connections()
+
     {:noreply, %{state | outbound_peers: MapSet.put(state.outbound_peers, peer)}}
   end
 
@@ -50,6 +51,7 @@ defmodule ExWire.ConnectionObserver do
         {:EXIT, _pid, {_, %Connection{is_outbound: false, peer: peer}}},
         state
       ) do
+    IO.inspect(state.inbound_peers)
     {:noreply, %{state | inbound_peers: MapSet.put(state.inbound_peers, peer)}}
   end
 

--- a/apps/ex_wire/lib/ex_wire/dev_p2p.ex
+++ b/apps/ex_wire/lib/ex_wire/dev_p2p.ex
@@ -48,10 +48,11 @@ defmodule ExWire.DEVp2p do
     %{session | hello_sent: hello}
   end
 
-  @doc """
+  '''
   Function to update `ExWire.DEVp2p.Session` when a handshake is received. The
   handshake should be an `ExWire.Packet.Protocol.Hello` that we have received from a peer.
-  """
+  '''
+
   @spec hello_received(Session.t(), Hello.t()) :: Session.t()
   def hello_received(session, hello = %Hello{}) do
     Session.hello_received(session, hello)

--- a/apps/ex_wire/lib/ex_wire/dev_p2p.ex
+++ b/apps/ex_wire/lib/ex_wire/dev_p2p.ex
@@ -48,16 +48,6 @@ defmodule ExWire.DEVp2p do
     %{session | hello_sent: hello}
   end
 
-  '''
-  Function to update `ExWire.DEVp2p.Session` when a handshake is received. The
-  handshake should be an `ExWire.Packet.Protocol.Hello` that we have received from a peer.
-  '''
-
-  @spec hello_received(Session.t(), Hello.t()) :: Session.t()
-  def hello_received(session, hello = %Hello{}) do
-    Session.hello_received(session, hello)
-  end
-
   @doc """
   Function to check whether or not a `ExWire.DEVp2p.Session` is active. See
   `ExWire.DEVp2p.Session.active?/1` for more information.
@@ -83,7 +73,7 @@ defmodule ExWire.DEVp2p do
   @spec handle_message(Session.t(), struct()) ::
           {:error, :handshake_incomplete} | {:ok, Session.t()}
   def handle_message(session, packet = %Hello{}) do
-    {:ok, hello_received(session, packet)}
+    {:ok, Session.hello_received(session, packet)}
   end
 
   def handle_message(_session, _message) do

--- a/apps/ex_wire/lib/ex_wire/p2p/manager.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/manager.ex
@@ -12,12 +12,12 @@ defmodule ExWire.P2P.Manager do
   alias ExWire.DEVp2p.Session
   alias ExWire.Handshake.Struct.AuthMsgV4
   alias ExWire.P2P.Connection
+  alias ExWire.Packet.Capability
   alias ExWire.Packet.PacketIdMap
-  alias ExWire.Packet.Protocol.Hello
   alias ExWire.Packet.Protocol.Disconnect
+  alias ExWire.Packet.Protocol.Hello
   alias ExWire.Packet.Protocol.Ping
   alias ExWire.Packet.Protocol.Pong
-  alias ExWire.Packet.Capability
   alias ExWire.Struct.Peer
 
   @doc """

--- a/apps/ex_wire/lib/ex_wire/p2p/manager.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/manager.ex
@@ -13,6 +13,11 @@ defmodule ExWire.P2P.Manager do
   alias ExWire.Handshake.Struct.AuthMsgV4
   alias ExWire.P2P.Connection
   alias ExWire.Packet.PacketIdMap
+  alias ExWire.Packet.Protocol.Hello
+  alias ExWire.Packet.Protocol.Disconnect
+  alias ExWire.Packet.Protocol.Ping
+  alias ExWire.Packet.Protocol.Pong
+  alias ExWire.Packet.Capability
   alias ExWire.Struct.Peer
 
   @doc """
@@ -60,10 +65,12 @@ defmodule ExWire.P2P.Manager do
   TODO: clients may send an auth before (or as) we do, and we should handle this
         case without error.
   """
+  # handle inbound message
   def handle_message(conn = %{secrets: %ExWire.Framing.Secrets{}}, data) do
     handle_packet_data(data, %{conn | last_error: nil})
   end
 
+  # handle outbound message
   def handle_message(conn = %{handshake: %Handshake{}}, data) do
     conn
     |> handle_encrypted_handshake(data)
@@ -150,29 +157,45 @@ defmodule ExWire.P2P.Manager do
   defp handle_packet(packet_mod, packet, conn) do
     packet_handle_response = packet_mod.handle(packet)
     session_status = if DEVp2p.session_active?(conn.session), do: :active, else: :inactive
+    do_handle_packet(packet_mod, packet, session_status, packet_handle_response, conn)
+  end
 
-    case {session_status, packet_handle_response} do
-      {:active, :ok} ->
-        conn
+  @spec do_handle_packet(
+          Hello | Ping | Pong | Disconnect,
+          Packet.packet(),
+          :active | :inactive,
+          {:disconnect, :useless_peer, [Capability.t()], non_neg_integer()}
+          | {:activate, [Capability.t()], non_neg_integer()}
+          | :peer_disconnect
+          | :ok,
+          Connection.t()
+        ) :: Connection.t()
+  defp do_handle_packet(Hello, _, _, {:disconnect, :useless_peer, caps, p2p_version}, conn) do
+    disconnect_packet = Disconnect.new(:useless_peer)
 
-      {:inactive, :activate} ->
-        new_session = attempt_session_activation(conn.session, packet)
+    send_packet(
+      %{conn | peer: %{conn.peer | p2p_version: p2p_version, caps: caps}},
+      disconnect_packet
+    )
+  end
 
-        %{conn | session: new_session}
+  defp do_handle_packet(Hello, packet, :inactive, {:activate, caps, p2p_version}, conn) do
+    new_session = attempt_session_activation(conn.session, packet)
+    %{conn | peer: %{conn.peer | p2p_version: p2p_version, caps: caps}, session: new_session}
+  end
 
-      {_, :peer_disconnect} ->
-        _ = TCP.shutdown(conn.socket)
+  defp do_handle_packet(Ping, _, :active, {:send, return_packet}, conn) do
+    send_packet(conn, return_packet)
+  end
 
-        conn
+  defp do_handle_packet(Pong, _, :active, :ok, conn) do
+    conn
+  end
 
-      {_, {:disconnect, reason}} ->
-        disconnect_packet = Packet.Protocol.Disconnect.new(reason)
+  defp do_handle_packet(Disconnect, _, _, :peer_disconnect, conn) do
+    _ = TCP.shutdown(conn.socket)
 
-        send_packet(conn, disconnect_packet)
-
-      {:active, {:send, return_packet}} ->
-        send_packet(conn, return_packet)
-    end
+    conn
   end
 
   @spec attempt_session_activation(Session.t(), Packet.packet()) :: Session.t()

--- a/apps/ex_wire/lib/ex_wire/p2p/manager.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/manager.ex
@@ -12,7 +12,6 @@ defmodule ExWire.P2P.Manager do
   alias ExWire.DEVp2p.Session
   alias ExWire.Handshake.Struct.AuthMsgV4
   alias ExWire.P2P.Connection
-  alias ExWire.Packet.Capability
   alias ExWire.Packet.PacketIdMap
   alias ExWire.Packet.Protocol.Disconnect
   alias ExWire.Struct.Peer
@@ -158,16 +157,6 @@ defmodule ExWire.P2P.Manager do
     do_handle_packet(packet, session_status, packet_handle_response, conn)
   end
 
-  @spec do_handle_packet(
-          Packet.packet(),
-          :active | :inactive,
-          {:disconnect, :useless_peer, [Capability.t()], non_neg_integer()}
-          | {:disconnect, :useless_peer}
-          | {:activate, [Capability.t()], non_neg_integer()}
-          | :peer_disconnect
-          | :ok,
-          Connection.t()
-        ) :: Connection.t()
   defp do_handle_packet(_, _, {:disconnect, :useless_peer}, conn) do
     disconnect_packet = Disconnect.new(:useless_peer)
 

--- a/apps/ex_wire/lib/ex_wire/packet.ex
+++ b/apps/ex_wire/lib/ex_wire/packet.ex
@@ -4,10 +4,11 @@ defmodule ExWire.Packet do
   the DevP2P and Eth Wire Protocols. They also handle how to respond
   to incoming packets.
   """
-
+  alias ExWire.Packet.Capability
   @type packet :: struct()
   @type block_identifier :: binary() | integer()
   @type block_hash :: {binary(), integer()}
+  @type p2p_version :: non_neg_integer()
 
   @callback message_id_offset() :: integer()
   @callback serialize(packet) :: ExRLP.t()
@@ -15,6 +16,10 @@ defmodule ExWire.Packet do
   # @callback summary(packet) :: String.t()
 
   @type handle_response ::
-          :ok | :activate | :peer_disconnect | {:disconnect, atom()} | {:send, struct()}
+          :ok
+          | {:activate, [Capability.t()], p2p_version()}
+          | :peer_disconnect
+          | {:disconnect, atom(), [Capability.t()], p2p_version()}
+          | {:send, struct()}
   @callback handle(packet) :: handle_response
 end

--- a/apps/ex_wire/lib/ex_wire/packet.ex
+++ b/apps/ex_wire/lib/ex_wire/packet.ex
@@ -19,7 +19,10 @@ defmodule ExWire.Packet do
           :ok
           | {:activate, [Capability.t()], p2p_version()}
           | :peer_disconnect
+          # hello
           | {:disconnect, atom(), [Capability.t()], p2p_version()}
+          # status
+          | {:disconnect, atom()}
           | {:send, struct()}
   @callback handle(packet) :: handle_response
 end

--- a/apps/ex_wire/lib/ex_wire/packet/protocol/hello.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/protocol/hello.ex
@@ -26,7 +26,7 @@ defmodule ExWire.Packet.Protocol.Hello do
   @behaviour ExWire.Packet
 
   @type t :: %__MODULE__{
-          p2p_version: integer(),
+          p2p_version: non_neg_integer(),
           client_id: String.t(),
           caps: [Capability.t()],
           listen_port: integer(),
@@ -129,10 +129,10 @@ defmodule ExWire.Packet.Protocol.Hello do
           "[Packet] Disconnecting due to no matching peer caps (#{inspect(packet.caps)})"
         end)
 
-      {:disconnect, :useless_peer}
+      {:disconnect, :useless_peer, packet.caps, packet.p2p_version}
     else
       # TODO: Add a bunch more checks
-      :activate
+      {:activate, packet.caps, packet.p2p_version}
     end
   end
 end

--- a/apps/ex_wire/lib/ex_wire/packet/protocol/hello.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/protocol/hello.ex
@@ -104,19 +104,23 @@ defmodule ExWire.Packet.Protocol.Hello do
   ## Examples
 
       # Matching caps
-      iex> %ExWire.Packet.Protocol.Hello{p2p_version: 10, client_id: "Mana/Test", caps: [ExWire.Packet.Capability.new({"eth", 62}), ExWire.Packet.Capability.new({"par", 2})], listen_port: 5555, node_id: <<5>>}
+
+      iex> caps = [ExWire.Packet.Capability.new({"eth", 62}), ExWire.Packet.Capability.new({"par", 2})]
+      iex> %ExWire.Packet.Protocol.Hello{p2p_version: 10, client_id: "Mana/Test", caps: caps, listen_port: 5555, node_id: <<5>>}
       ...> |> ExWire.Packet.Protocol.Hello.handle()
-      :activate
+      {:activate, [ExWire.Packet.Capability.new({"eth", 62}), ExWire.Packet.Capability.new({"par", 2})], 10}
 
       # No matching caps
-      iex> %ExWire.Packet.Protocol.Hello{p2p_version: 10, client_id: "Mana/Test", caps: [ExWire.Packet.Capability.new({"eth", 1}), ExWire.Packet.Capability.new({"par", 2})], listen_port: 5555, node_id: <<5>>}
+
+      iex> caps = [ExWire.Packet.Capability.new({"eth", 1}), ExWire.Packet.Capability.new({"par", 2})]
+      iex> %ExWire.Packet.Protocol.Hello{p2p_version: 10, client_id: "Mana/Test", caps: caps, listen_port: 5555, node_id: <<5>>}
       ...> |> ExWire.Packet.Protocol.Hello.handle()
-      {:disconnect, :useless_peer}
+      {:disconnect, :useless_peer, [ExWire.Packet.Capability.new({"eth", 1}), ExWire.Packet.Capability.new({"par", 2})], 10}
 
       # When no caps
       iex> %ExWire.Packet.Protocol.Hello{p2p_version: 10, client_id: "Mana/Test", caps: [], listen_port: 5555, node_id: <<5>>}
       ...> |> ExWire.Packet.Protocol.Hello.handle()
-      {:disconnect, :useless_peer}
+      {:disconnect, :useless_peer, [], 10}
   """
   @impl true
   @spec handle(ExWire.Packet.packet()) :: ExWire.Packet.handle_response()

--- a/apps/ex_wire/lib/ex_wire/struct/peer.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/peer.ex
@@ -1,6 +1,8 @@
 defmodule ExWire.Struct.Peer do
   @moduledoc """
   Represents a Peer for an RLPx / Eth Wire connection.
+  Caps and p2p_version are set after we exchange the Hello message. It helps us
+  establish a quality of a particular peer.
   """
 
   defstruct [
@@ -8,19 +10,24 @@ defmodule ExWire.Struct.Peer do
     :host_name,
     :port,
     :remote_id,
-    :ident
+    :ident,
+    :caps,
+    :p2p_version
   ]
 
   alias ExthCrypto.Key
   alias ExWire.Crypto
   alias ExWire.Kademlia.Node
+  alias ExWire.Packet.Capability
 
   @type t :: %__MODULE__{
           host: :inet.socket_address() | :inet.hostname(),
           host_name: String.t(),
           port: :inet.port_number(),
           remote_id: Key.public_key(),
-          ident: String.t()
+          ident: String.t(),
+          caps: [Capability.t()],
+          p2p_version: non_neg_integer() | nil
         }
 
   @doc """
@@ -50,7 +57,8 @@ defmodule ExWire.Struct.Peer do
       host_name: inet_host_to_uri_host(host),
       port: port,
       remote_id: remote_id,
-      ident: ident
+      ident: ident,
+      caps: []
     }
   end
 

--- a/apps/ex_wire/lib/ex_wire/struct/peer.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/peer.ex
@@ -5,15 +5,13 @@ defmodule ExWire.Struct.Peer do
   establish a quality of a particular peer.
   """
 
-  defstruct [
-    :host,
-    :host_name,
-    :port,
-    :remote_id,
-    :ident,
-    :caps,
-    :p2p_version
-  ]
+  defstruct host: nil,
+            host_name: nil,
+            port: nil,
+            remote_id: nil,
+            ident: nil,
+            caps: [],
+            p2p_version: nil
 
   alias ExthCrypto.Key
   alias ExWire.Crypto

--- a/apps/ex_wire/test/ex_wire/dev_p2p_test.exs
+++ b/apps/ex_wire/test/ex_wire/dev_p2p_test.exs
@@ -3,100 +3,100 @@ defmodule ExWire.DEVp2pTest do
   doctest ExWire.DEVp2p
   doctest ExWire.DEVp2p.Session
 
-  import ExWire.DEVp2p
+  alias ExWire.DEVp2p
 
   alias ExWire.Packet
   alias ExWire.Packet.Capability
 
   describe "handles protocol handshake" do
     test "activates session if Hello is sent and received" do
-      our_hello = build_hello()
-      peer_hello = build_hello()
+      our_hello = DEVp2p.build_hello()
+      peer_hello = DEVp2p.build_hello()
 
       session =
-        init_session()
-        |> hello_sent(our_hello)
-        |> hello_received(peer_hello)
+        DEVp2p.init_session()
+        |> DEVp2p.hello_sent(our_hello)
+        |> DEVp2p.hello_received(peer_hello)
 
-      assert session_active?(session)
+      assert DEVp2p.session_active?(session)
     end
 
     test "does not activate the session if hello is only sent" do
-      our_hello = build_hello()
+      our_hello = DEVp2p.build_hello()
 
       session =
-        init_session()
-        |> hello_sent(our_hello)
+        DEVp2p.init_session()
+        |> DEVp2p.hello_sent(our_hello)
 
-      refute session_active?(session)
+      refute DEVp2p.session_active?(session)
     end
 
     test "does not activate the session if hello is only received" do
-      peer_hello = build_hello()
+      peer_hello = DEVp2p.build_hello()
 
       session =
-        init_session()
-        |> hello_received(peer_hello)
+        DEVp2p.init_session()
+        |> DEVp2p.hello_received(peer_hello)
 
-      refute session_active?(session)
+      refute DEVp2p.session_active?(session)
     end
 
     test "does not activate session if capabilities to not overlap" do
-      our_hello = build_hello()
-      peer_hello = build_hello() |> set_older_capability()
+      our_hello = DEVp2p.build_hello()
+      peer_hello = DEVp2p.build_hello() |> set_older_capability()
 
       session =
-        init_session()
-        |> hello_sent(our_hello)
-        |> hello_received(peer_hello)
+        DEVp2p.init_session()
+        |> DEVp2p.hello_sent(our_hello)
+        |> DEVp2p.hello_received(peer_hello)
 
-      refute session_active?(session)
+      refute DEVp2p.session_active?(session)
     end
   end
 
   describe "session_compatible?/1" do
     test "returns true if any capabilities overlap" do
-      our_hello = build_hello()
-      peer_hello = build_hello()
+      our_hello = DEVp2p.build_hello()
+      peer_hello = DEVp2p.build_hello()
 
       session =
-        init_session()
-        |> hello_sent(our_hello)
-        |> hello_received(peer_hello)
+        DEVp2p.init_session()
+        |> DEVp2p.hello_sent(our_hello)
+        |> DEVp2p.hello_received(peer_hello)
 
-      assert session_compatible?(session)
+      assert DEVp2p.session_compatible?(session)
     end
 
     test "returns false if no capabilities overlap" do
-      our_hello = build_hello()
-      peer_hello = build_hello() |> set_older_capability()
+      our_hello = DEVp2p.build_hello()
+      peer_hello = DEVp2p.build_hello() |> set_older_capability()
 
       session =
-        init_session()
-        |> hello_sent(our_hello)
-        |> hello_received(peer_hello)
+        DEVp2p.init_session()
+        |> DEVp2p.hello_sent(our_hello)
+        |> DEVp2p.hello_received(peer_hello)
 
-      refute session_compatible?(session)
+      refute DEVp2p.session_compatible?(session)
     end
   end
 
   describe "handle_message/2" do
     test "returns error if message is not Hello" do
       ping = %Packet.Protocol.Ping{}
-      session = init_session()
+      session = DEVp2p.init_session()
 
-      assert {:error, :handshake_incomplete} = handle_message(session, ping)
+      assert {:error, :handshake_incomplete} = DEVp2p.handle_message(session, ping)
     end
 
     test "activates a session when Hello message is compatible" do
-      hello = build_hello()
+      hello = DEVp2p.build_hello()
 
       {:ok, session} =
-        init_session()
-        |> hello_sent(build_hello())
-        |> handle_message(hello)
+        DEVp2p.init_session()
+        |> DEVp2p.hello_sent(DEVp2p.build_hello())
+        |> DEVp2p.handle_message(hello)
 
-      assert session_active?(session)
+      assert DEVp2p.session_active?(session)
     end
   end
 
@@ -105,11 +105,11 @@ defmodule ExWire.DEVp2pTest do
   end
 
   def active_session do
-    our_hello = build_hello()
-    peer_hello = build_hello()
+    our_hello = DEVp2p.build_hello()
+    peer_hello = DEVp2p.build_hello()
 
-    init_session()
-    |> hello_sent(our_hello)
-    |> hello_received(peer_hello)
+    DEVp2p.init_session()
+    |> DEVp2p.hello_sent(our_hello)
+    |> DEVp2p.hello_received(peer_hello)
   end
 end

--- a/apps/ex_wire/test/ex_wire/dev_p2p_test.exs
+++ b/apps/ex_wire/test/ex_wire/dev_p2p_test.exs
@@ -4,7 +4,6 @@ defmodule ExWire.DEVp2pTest do
   doctest ExWire.DEVp2p.Session
 
   alias ExWire.DEVp2p
-
   alias ExWire.Packet
   alias ExWire.Packet.Capability
 
@@ -13,10 +12,10 @@ defmodule ExWire.DEVp2pTest do
       our_hello = DEVp2p.build_hello()
       peer_hello = DEVp2p.build_hello()
 
-      session =
+      {:ok, session} =
         DEVp2p.init_session()
         |> DEVp2p.hello_sent(our_hello)
-        |> DEVp2p.hello_received(peer_hello)
+        |> DEVp2p.handle_message(peer_hello)
 
       assert DEVp2p.session_active?(session)
     end
@@ -34,9 +33,9 @@ defmodule ExWire.DEVp2pTest do
     test "does not activate the session if hello is only received" do
       peer_hello = DEVp2p.build_hello()
 
-      session =
+      {:ok, session} =
         DEVp2p.init_session()
-        |> DEVp2p.hello_received(peer_hello)
+        |> DEVp2p.handle_message(peer_hello)
 
       refute DEVp2p.session_active?(session)
     end
@@ -45,10 +44,10 @@ defmodule ExWire.DEVp2pTest do
       our_hello = DEVp2p.build_hello()
       peer_hello = DEVp2p.build_hello() |> set_older_capability()
 
-      session =
+      {:ok, session} =
         DEVp2p.init_session()
         |> DEVp2p.hello_sent(our_hello)
-        |> DEVp2p.hello_received(peer_hello)
+        |> DEVp2p.handle_message(peer_hello)
 
       refute DEVp2p.session_active?(session)
     end
@@ -59,10 +58,10 @@ defmodule ExWire.DEVp2pTest do
       our_hello = DEVp2p.build_hello()
       peer_hello = DEVp2p.build_hello()
 
-      session =
+      {:ok, session} =
         DEVp2p.init_session()
         |> DEVp2p.hello_sent(our_hello)
-        |> DEVp2p.hello_received(peer_hello)
+        |> DEVp2p.handle_message(peer_hello)
 
       assert DEVp2p.session_compatible?(session)
     end
@@ -71,10 +70,10 @@ defmodule ExWire.DEVp2pTest do
       our_hello = DEVp2p.build_hello()
       peer_hello = DEVp2p.build_hello() |> set_older_capability()
 
-      session =
+      {:ok, session} =
         DEVp2p.init_session()
         |> DEVp2p.hello_sent(our_hello)
-        |> DEVp2p.hello_received(peer_hello)
+        |> DEVp2p.handle_message(peer_hello)
 
       refute DEVp2p.session_compatible?(session)
     end

--- a/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
@@ -68,7 +68,12 @@ defmodule JSONRPC2.ManaHandlerTest do
 
   describe "is net_peerCount method behaving correctly when" do
     setup do
-      {:ok, pid} = BridgeSyncMock.start_link(%{})
+      pid =
+        case BridgeSyncMock.start_link(%{}) do
+          {:error, {:already_started, pid}} -> pid
+          {:ok, pid} -> pid
+        end
+
       {:ok, %{pid: pid}}
     end
 
@@ -101,7 +106,12 @@ defmodule JSONRPC2.ManaHandlerTest do
 
   describe "is eth_syncing method behaving correctly when" do
     setup do
-      {:ok, pid} = BridgeSyncMock.start_link(%{})
+      pid =
+        case BridgeSyncMock.start_link(%{}) do
+          {:error, {:already_started, pid}} -> pid
+          {:ok, pid} -> pid
+        end
+
       {:ok, %{pid: pid}}
     end
 


### PR DESCRIPTION
This expand a Peer struct with p2p_version and caps. 1. Setup for rating and 2. Both Parity and Geth support JSONRPC admin methods where caps is returned for connected peers. 
My next step in the works is to create a separate struct that will have Peer + other related fields that will help us maintain Peers rating, but related just to ratings. 