### PR TITLE
add transaction getter methods for JSON RPC API

### DIFF
--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -4,6 +4,7 @@ defmodule JSONRPC2.Bridge.Sync do
   alias ExWire.PeerSupervisor
   alias ExWire.Sync
   alias JSONRPC2.Response.Block, as: ResponseBlock
+  alias JSONRPC2.Response.Transaction, as: ResponseTransaction
 
   @spec connected_peer_count :: 0 | non_neg_integer()
   def connected_peer_count, do: PeerSupervisor.connected_peer_count()

--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -28,20 +28,46 @@ defmodule JSONRPC2.Bridge.Sync do
   @spec get_last_sync_state() :: Sync.state()
   defp get_last_sync_state(), do: Sync.get_state()
 
-  def get_block_by_number(number, full_transactions) do
+  def get_block_by_number(number) do
     state_trie = get_last_sync_state().trie
 
     case Block.get_block_by_number(number, state_trie) do
-      {:ok, block} -> ResponseBlock.new(block, full_transactions)
+      {:ok, block} -> ResponseBlock.new(block)
       _ -> nil
     end
   end
 
-  def get_block_by_hash(hash, full_transactions) do
+  def get_block_by_hash(hash) do
     state_trie = get_last_sync_state().trie
 
     case Block.get_block(hash, state_trie) do
-      {:ok, block} -> ResponseBlock.new(block, full_transactions)
+      {:ok, block} -> ResponseBlock.new(block)
+      _ -> nil
+    end
+  end
+
+  def get_transaction_by_block_hash_and_index(block_hash, trx_index) do
+    trie = get_last_sync_state().trie
+
+    with {:ok, block} <- Block.get_block(block_hash, trie) do
+      case Enum.at(block.transactions, trx_index) do
+        nil -> nil
+        transaction -> ResponseTransaction.new(transaction, block)
+      end
+    else
+      _ -> nil
+    end
+  end
+
+  def get_transaction_by_block_number_and_index(block_number, trx_index) do
+    trie = get_last_sync_state().trie
+
+    with {:ok, block} <- Block.get_block_by_number(block_number, trie) do
+      case Enum.at(block.transactions, trx_index) do
+        nil -> nil
+        transaction -> ResponseTransaction.new(transaction, block)
+      end
+    else
       _ -> nil
     end
   end

--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -28,20 +28,20 @@ defmodule JSONRPC2.Bridge.Sync do
   @spec get_last_sync_state() :: Sync.state()
   defp get_last_sync_state(), do: Sync.get_state()
 
-  def get_block_by_number(number) do
+  def get_block_by_number(number, full_transactions) do
     state_trie = get_last_sync_state().trie
 
     case Block.get_block_by_number(number, state_trie) do
-      {:ok, block} -> ResponseBlock.new(block)
+      {:ok, block} -> ResponseBlock.new(block, full_transactions)
       _ -> nil
     end
   end
 
-  def get_block_by_hash(hash) do
+  def get_block_by_hash(hash, full_transactions) do
     state_trie = get_last_sync_state().trie
 
     case Block.get_block(hash, state_trie) do
-      {:ok, block} -> ResponseBlock.new(block)
+      {:ok, block} -> ResponseBlock.new(block, full_transactions)
       _ -> nil
     end
   end

--- a/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
@@ -86,7 +86,21 @@ defmodule JSONRPC2.SpecHandler do
   end
 
   def handle_request("eth_getTransactionByHash", _), do: {:error, :not_supported}
-  def handle_request("eth_getTransactionByBlockHashAndIndex", _), do: {:error, :not_supported}
+
+  def handle_request("eth_getTransactionByBlockHashAndIndex", [
+        block_hash_hex,
+        transaction_index_hex
+      ]) do
+    block_hash = Math.hex_to_bin(block_hash_hex)
+
+    transaction_index =
+      transaction_index_hex
+      |> Math.hex_to_bin()
+      |> :binary.decode_unsigned()
+
+    @sync.get_transaction_by_block_hash_and_index(block_hash, transaction_index)
+  end
+
   def handle_request("eth_getTransactionByBlockNumberAndIndex", _), do: {:error, :not_supported}
   def handle_request("eth_getTransactionReceipt", _), do: {:error, :not_supported}
   def handle_request("eth_getUncleByBlockHashAndIndex", _), do: {:error, :not_supported}

--- a/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
@@ -101,7 +101,18 @@ defmodule JSONRPC2.SpecHandler do
     @sync.get_transaction_by_block_hash_and_index(block_hash, transaction_index)
   end
 
-  def handle_request("eth_getTransactionByBlockNumberAndIndex", _), do: {:error, :not_supported}
+  def handle_request("eth_getTransactionByBlockNumberAndIndex", [
+        block_number,
+        transaction_index_hex
+      ]) do
+    transaction_index =
+      transaction_index_hex
+      |> Math.hex_to_bin()
+      |> :binary.decode_unsigned()
+
+    @sync.get_transaction_by_block_number_and_index(block_number, transaction_index)
+  end
+
   def handle_request("eth_getTransactionReceipt", _), do: {:error, :not_supported}
   def handle_request("eth_getUncleByBlockHashAndIndex", _), do: {:error, :not_supported}
   def handle_request("eth_getUncleByBlockNumberAndIndex", _), do: {:error, :not_supported}

--- a/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
@@ -3,7 +3,7 @@ defmodule JSONRPC2.ManaHandlerTest do
 
   alias JSONRPC2.BridgeSyncMock
   alias JSONRPC2.SpecHandler
-  import JSONRPC2.TestFactory
+  alias JSONRPC2.TestFactory
 
   setup_all do
     db = MerklePatriciaTree.Test.random_ets_db()
@@ -126,9 +126,14 @@ defmodule JSONRPC2.ManaHandlerTest do
     end
   end
 
-  describe "eth_getTransactionByNumber" do
-    test "fetches transaction by number" do
-      block = build(:block, block_hash: <<0x2::256>>, header: build(:header, number: 10))
+  describe "eth_getBlockByNumber" do
+    test "fetches block by number" do
+      block =
+        TestFactory.build(:block,
+          block_hash: <<0x2::256>>,
+          header: TestFactory.build(:header, number: 10)
+        )
+
       :ok = BridgeSyncMock.put_block(block)
 
       assert_rpc_reply(
@@ -139,9 +144,9 @@ defmodule JSONRPC2.ManaHandlerTest do
     end
   end
 
-  describe "eth_getTransactionByHash" do
-    test "fetches transaction by hash" do
-      block = build(:block, block_hash: <<100::256>>)
+  describe "eth_getBlockByHash" do
+    test "fetches block by hash" do
+      block = TestFactory.build(:block, block_hash: <<100::256>>)
 
       :ok = BridgeSyncMock.put_block(block)
 
@@ -149,6 +154,20 @@ defmodule JSONRPC2.ManaHandlerTest do
         SpecHandler,
         ~s({"jsonrpc": "2.0", "method": "eth_getBlockByHash", "params": ["0x0000000000000000000000000000000000000000000000000000000000000064", false], "id": 71}),
         ~s({"id":71,"jsonrpc":"2.0","result":{"difficulty":"0x01","extraData":"","gasLimit":"0x00","gasUsed":"0x00","hash":"0x0000000000000000000000000000000000000000000000000000000000000064","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0x0000000000000000000000000000000000000010","nonce":"0x0000000000000000","number":"0x01","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000010","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","sha3Uncles":"0x0000000000000000000000000000000000000000000000000000000000000010","size":"0x01f5","stateRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","timestamp":"0x01","totalDifficulty":"0x01","transactions":[],"transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","uncles":[]}})
+      )
+    end
+  end
+
+  describe "eth_getTransactionByBlockHashAndIndex" do
+    test "fetches transaction by block hash and index" do
+      transaction = TestFactory.build(:transaction)
+      block = TestFactory.build(:block, block_hash: <<0x3::256>>, transactions: [transaction])
+      :ok = BridgeSyncMock.put_block(block)
+
+      assert_rpc_reply(
+        SpecHandler,
+        ~s({"jsonrpc": "2.0", "method": "eth_getTransactionByBlockHashAndIndex", "params": ["0x0000000000000000000000000000000000000000000000000000000000000003", "0x00"], "id": 71}),
+        ~s({"id":71, "jsonrpc":"2.0", "result":{"hash":"0x71024c28d1404f5d5fe3458b71b02d799f6d6aba29e285857732c0d06ebf3b08", "nonce":"0x05", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000003", "blockNumber":"0x01", "from":"0x619f56e8bed07fe196c0dbc41b52e2bc64817b3a", "gas":"0x07", "gasPrice":"0x06", "input":"0x01", "r":"0x55fa77ee62e6c42e83b4f868c1e41643e45fd6f02a381a663318884751cb690a", "s":"0x7bd63c407cea7d619d598fb5766980ab8497b1b11c26d8bc59a132af96317793", "to":"0x", "transactionIndex":"0x00", "v":"0x1b", "value":"0x05"}})
       )
     end
   end

--- a/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
@@ -172,6 +172,27 @@ defmodule JSONRPC2.ManaHandlerTest do
     end
   end
 
+  describe "eth_getTransactionByBlockNumberAndIndex" do
+    test "fetches transaction by block number and index" do
+      transaction = TestFactory.build(:transaction)
+
+      block =
+        TestFactory.build(:block,
+          block_hash: <<0x3::256>>,
+          transactions: [transaction],
+          header: TestFactory.build(:header, number: 99)
+        )
+
+      :ok = BridgeSyncMock.put_block(block)
+
+      assert_rpc_reply(
+        SpecHandler,
+        ~s({"jsonrpc": "2.0", "method": "eth_getTransactionByBlockNumberAndIndex", "params": [99, "0x00"], "id": 71}),
+        ~s({"id":71, "jsonrpc":"2.0", "result":{"hash":"0x71024c28d1404f5d5fe3458b71b02d799f6d6aba29e285857732c0d06ebf3b08", "nonce":"0x05", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000003", "blockNumber":"0x63", "from":"0x619f56e8bed07fe196c0dbc41b52e2bc64817b3a", "gas":"0x07", "gasPrice":"0x06", "input":"0x01", "r":"0x55fa77ee62e6c42e83b4f868c1e41643e45fd6f02a381a663318884751cb690a", "s":"0x7bd63c407cea7d619d598fb5766980ab8497b1b11c26d8bc59a132af96317793", "to":"0x", "transactionIndex":"0x00", "v":"0x1b", "value":"0x05"}})
+      )
+    end
+  end
+
   defp assert_rpc_reply(handler, call, expected_reply) do
     assert {:reply, reply} = handler.handle(call)
 

--- a/apps/jsonrpc2/test/support/bridge_sync_mock.ex
+++ b/apps/jsonrpc2/test/support/bridge_sync_mock.ex
@@ -1,6 +1,7 @@
 defmodule JSONRPC2.BridgeSyncMock do
   alias Blockchain.Block
   alias JSONRPC2.Response.Block, as: ResponseBlock
+  alias JSONRPC2.Response.Transaction, as: ResponseTransaction
   alias JSONRPC2.Struct.EthSyncing
 
   use GenServer
@@ -31,6 +32,10 @@ defmodule JSONRPC2.BridgeSyncMock do
 
   def get_block_by_hash(hash) do
     GenServer.call(__MODULE__, {:get_block_by_hash, hash})
+  end
+
+  def get_transaction_by_block_hash_and_index(block_hash, index) do
+    GenServer.call(__MODULE__, {:get_transaction_by_block_hash_and_index, block_hash, index})
   end
 
   def start_link(state) do
@@ -74,6 +79,24 @@ defmodule JSONRPC2.BridgeSyncMock do
       end
 
     {:reply, block, state}
+  end
+
+  def handle_call(
+        {:get_transaction_by_block_hash_and_index, block_hash, trx_index},
+        _,
+        state = %{trie: trie}
+      ) do
+    result =
+      with {:ok, block} <- Block.get_block(block_hash, trie) do
+        case Enum.at(block.transactions, trx_index) do
+          nil -> nil
+          transaction -> ResponseTransaction.new(transaction, block)
+        end
+      else
+        _ -> nil
+      end
+
+    {:reply, result, state}
   end
 
   @spec handle_call(:get_last_sync_block_stats, {pid, any}, map()) ::


### PR DESCRIPTION
Changes:
- Implement `eth_getTransactionByBlockNumberAndIndex` JSON RPC method
- Implement `eth_getTransactionByBlockHashAndIndex` JSON RPC method

part of https://github.com/mana-ethereum/mana/issues/675