### PR TITLE
fetch receipt from database for JSON RPC

### DIFF
--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -376,6 +376,30 @@ defmodule Blockchain.Block do
     end
   end
 
+  @spec get_receipt_by_transaction_hash(binary(), TrieStorage.t()) ::
+          {Receipt.t(), Transaction.t(), Block.t()}
+  def get_receipt_by_transaction_hash(transaction_hash, trie) do
+    case get_transaction_by_hash(transaction_hash, trie, true) do
+      {transaction, block} ->
+        location_key = transaction_key(transaction_hash)
+
+        case TrieStorage.get_raw_key(trie, location_key) do
+          {:ok, location_bin} ->
+            {_block_hash, transaction_index} = :erlang.binary_to_term(location_bin)
+
+            receipt = Enum.at(block.receipts, transaction_index)
+
+            {receipt, transaction, block}
+
+          _ ->
+            nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
   @doc """
   Returns a given transaction from a block. This is
   based on the transactions root where all transactions

--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -377,7 +377,7 @@ defmodule Blockchain.Block do
   end
 
   @spec get_receipt_by_transaction_hash(binary(), TrieStorage.t()) ::
-          {Receipt.t(), Transaction.t(), Block.t()}
+          {Receipt.t() | nil, Transaction.t() | nil, t()} | nil
   def get_receipt_by_transaction_hash(transaction_hash, trie) do
     case get_transaction_by_hash(transaction_hash, trie, true) do
       {transaction, block} ->
@@ -425,7 +425,8 @@ defmodule Blockchain.Block do
     end
   end
 
-  @spec get_transaction_by_hash(binary(), TrieStorage.t(), boolean()) :: Transaction.t() | nil
+  @spec get_transaction_by_hash(binary(), TrieStorage.t(), boolean()) ::
+          Transaction.t() | {Transaction.t(), t()} | nil
   def get_transaction_by_hash(transaction_hash, trie, with_block \\ false) do
     location_key = transaction_key(transaction_hash)
 

--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -195,7 +195,7 @@ defmodule JSONRPC2.Bridge.Sync do
 
     case Block.get_receipt_by_transaction_hash(transaction_hash, state_trie) do
       {receipt, transaction, block} -> ResponseReceipt.new(receipt, transaction, block)
-      _ -> nil
+      nil -> nil
     end
   end
 end

--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -5,6 +5,7 @@ defmodule JSONRPC2.Bridge.Sync do
   alias ExWire.PeerSupervisor
   alias ExWire.Sync
   alias JSONRPC2.Response.Block, as: ResponseBlock
+  alias JSONRPC2.Response.Receipt, as: ResponseReceipt
   alias JSONRPC2.Response.Transaction, as: ResponseTransaction
   alias MerklePatriciaTree.TrieStorage
 
@@ -186,6 +187,15 @@ defmodule JSONRPC2.Bridge.Sync do
     case Block.get_transaction_by_hash(transaction_hash, state_trie, true) do
       {transaction, block} -> ResponseTransaction.new(transaction, block)
       nil -> nil
+    end
+  end
+
+  def get_transaction_receipt(transaction_hash) do
+    state_trie = get_last_sync_state().trie
+
+    case Block.get_receipt_by_transaction_hash(transaction_hash, state_trie) do
+      {receipt, transaction, block} -> ResponseReceipt.new(receipt, transaction, block)
+      _ -> nil
     end
   end
 end

--- a/apps/jsonrpc2/lib/jsonrpc2/response/receipt.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/response/receipt.ex
@@ -62,7 +62,7 @@ defmodule JSONRPC2.Response.Receipt do
 
   defp transaction_index(transaction, block) do
     block.transactions
-    |> Enum.find_index(transaction)
+    |> Enum.find_index(fn trx -> trx == transaction end)
     |> encode_hex()
   end
 

--- a/apps/jsonrpc2/lib/jsonrpc2/response/receipt.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/response/receipt.ex
@@ -42,7 +42,7 @@ defmodule JSONRPC2.Response.Receipt do
 
     %__MODULE__{
       transactionHash: transaction_hash(transaction),
-      transactionIndex: index,
+      transactionIndex: encode_hex(index),
       blockHash: encode_hex(block.block_hash),
       blockNumber: encode_hex(block.header.number),
       from: from_address(transaction, network_id),
@@ -65,7 +65,6 @@ defmodule JSONRPC2.Response.Receipt do
   defp transaction_index(transaction, block) do
     block.transactions
     |> Enum.find_index(fn trx -> trx == transaction end)
-    |> encode_hex()
   end
 
   defp from_address(internal_transaction, network_id) do

--- a/apps/jsonrpc2/lib/jsonrpc2/response/receipt.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/response/receipt.ex
@@ -1,0 +1,74 @@
+defmodule JSONRPC2.Response.Receipt do
+  alias Blockchain.Transaction
+  alias Blockchain.Transaction.Signature
+
+  import JSONRPC2.Response.Helpers
+
+  @derive Jason.Encoder
+  defstruct [
+    :transactionHash,
+    :transactionIndex,
+    :blockHash,
+    :blockNumber,
+    :from,
+    :to,
+    :cumulativeGasUsed,
+    :gasUsed,
+    :contractAddress,
+    :logs,
+    :logsBloom,
+    :root,
+    :status
+  ]
+
+  @type t :: %__MODULE__{
+          transactionHash: binary(),
+          transactionIndex: binary(),
+          blockHash: binary(),
+          blockNumber: binary(),
+          from: binary(),
+          to: binary(),
+          cumulativeGasUsed: binary(),
+          gasUsed: binary(),
+          contractAddress: binary(),
+          logs: [],
+          logsBloom: binary(),
+          root: binary(),
+          status: binary()
+        }
+
+  def new(receipt, transaction, block, network_id \\ nil) do
+    %__MODULE__{
+      transactionHash: transaction_hash(transaction),
+      transactionIndex: transaction_index(transaction, block),
+      blockHash: encode_hex(block.block_hash),
+      blockNumber: encode_hex(block.header.number),
+      from: from_address(transaction, network_id),
+      to: encode_hex(transaction.to),
+      cumulativeGasUsed: encode_hex(receipt.cumulative_gas),
+      gasUsed: "",
+      contractAddress: "",
+      logs: [],
+      logsBloom: encode_hex(receipt.bloom_filter),
+      status: encode_hex(receipt.state)
+    }
+  end
+
+  defp transaction_hash(transaction) do
+    transaction
+    |> Transaction.hash()
+    |> encode_hex()
+  end
+
+  defp transaction_index(transaction, block) do
+    block.transactions
+    |> Enum.find_index(transaction)
+    |> encode_hex()
+  end
+
+  defp from_address(internal_transaction, network_id) do
+    {:ok, sender} = Signature.sender(internal_transaction, network_id)
+
+    encode_hex(sender)
+  end
+end

--- a/apps/jsonrpc2/lib/jsonrpc2/response/receipt.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/response/receipt.ex
@@ -1,5 +1,6 @@
 defmodule JSONRPC2.Response.Receipt do
   alias Blockchain.Transaction
+
   alias Blockchain.Transaction.Signature
 
   import JSONRPC2.Response.Helpers

--- a/apps/jsonrpc2/lib/jsonrpc2/response/transaction.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/response/transaction.ex
@@ -1,7 +1,6 @@
 defmodule JSONRPC2.Response.Transaction do
   alias Blockchain.Transaction
   alias Blockchain.Transaction.Signature
-  alias ExthCrypto.Hash.Keccak
 
   import JSONRPC2.Response.Helpers
 
@@ -71,9 +70,7 @@ defmodule JSONRPC2.Response.Transaction do
 
   defp hash(internal_transaction) do
     internal_transaction
-    |> Transaction.serialize()
-    |> ExRLP.encode()
-    |> Keccak.kec()
+    |> Transaction.hash()
     |> encode_hex()
   end
 

--- a/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
@@ -143,7 +143,12 @@ defmodule JSONRPC2.SpecHandler do
     @sync.get_transaction_by_block_number_and_index(block_number, transaction_index)
   end
 
-  def handle_request("eth_getTransactionReceipt", _), do: {:error, :not_supported}
+  def handle_request("eth_getTransactionReceipt", [hex_transaction_hash]) do
+    transaction_hash = Exth.decode_hex(hex_transaction_hash)
+
+    @sync.get_transaction_receipt(transaction_hash)
+  end
+
   def handle_request("eth_getUncleByBlockHashAndIndex", _), do: {:error, :not_supported}
   def handle_request("eth_getUncleByBlockNumberAndIndex", _), do: {:error, :not_supported}
   # eth_getCompilers is deprecated

--- a/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
@@ -511,6 +511,28 @@ defmodule JSONRPC2.ManaHandlerTest do
     end
   end
 
+  describe "eth_getTransactionReceipt" do
+    test "fetch receipt by transaction hash" do
+      transaction = TestFactory.build(:transaction)
+      receipt = TestFactory.build(:receipt)
+
+      block =
+        TestFactory.build(:block,
+          block_hash: <<0x1AAA::256>>,
+          transactions: [transaction],
+          receipts: [receipt]
+        )
+
+      :ok = BridgeSyncMock.put_block(block)
+
+      assert_rpc_reply(
+        SpecHandler,
+        ~s({"jsonrpc": "2.0", "method": "eth_getTransactionReceipt", "params": ["0x71024c28d1404f5d5fe3458b71b02d799f6d6aba29e285857732c0d06ebf3b08"], "id": 71}),
+        ~s({"id":71, "jsonrpc":"2.0", "result":{"blockNumber":"0x01", "from":"0x619f56e8bed07fe196c0dbc41b52e2bc64817b3a", "to":"0x", "transactionIndex":"0x00", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000001aaa", "contractAddress":"", "cumulativeGasUsed":"0x03e8", "gasUsed":"0x03e8", "logs":[], "logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "root":null, "status":"0x01", "transactionHash":"0x71024c28d1404f5d5fe3458b71b02d799f6d6aba29e285857732c0d06ebf3b08"}})
+      )
+    end
+  end
+
   defp assert_rpc_reply(handler, call, expected_reply) do
     assert {:reply, reply} = handler.handle(call)
 

--- a/apps/jsonrpc2/test/jsonrpc2/response/receipt_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/response/receipt_test.exs
@@ -1,0 +1,34 @@
+defmodule JSONRPC2.Response.ReceiptTest do
+  use ExUnit.Case, async: true
+
+  alias JSONRPC2.Response.Receipt
+  alias JSONRPC2.TestFactory
+
+  describe "new/4" do
+    test "creates response receipt from internal block" do
+      transaction = TestFactory.build(:transaction)
+      block = TestFactory.build(:block, transactions: [transaction])
+      receipt = TestFactory.build(:receipt)
+
+      response_receipt = Receipt.new(receipt, transaction, block)
+
+      assert response_receipt == %JSONRPC2.Response.Receipt{
+               blockHash: "0x0000000000000000000000000000000000000000000000000000000000000010",
+               blockNumber: "0x01",
+               contractAddress: "",
+               cumulativeGasUsed: "0x03e8",
+               from: "0x619f56e8bed07fe196c0dbc41b52e2bc64817b3a",
+               gasUsed: "0x03e8",
+               logs: [],
+               logsBloom:
+                 "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+               root: nil,
+               status: "0x01",
+               to: "0x",
+               transactionHash:
+                 "0x71024c28d1404f5d5fe3458b71b02d799f6d6aba29e285857732c0d06ebf3b08",
+               transactionIndex: "0x00"
+             }
+    end
+  end
+end

--- a/apps/jsonrpc2/test/support/bridge_sync_mock.ex
+++ b/apps/jsonrpc2/test/support/bridge_sync_mock.ex
@@ -36,6 +36,10 @@ defmodule JSONRPC2.BridgeSyncMock do
     GenServer.call(__MODULE__, {:get_code, address, block_number})
   end
 
+  def get_transaction_receipt(transaction_hash) do
+    GenServer.call(__MODULE__, {:get_transaction_receipt, transaction_hash})
+  end
+
   def get_balance(address, block_number) do
     GenServer.call(__MODULE__, {:get_balance, address, block_number})
   end
@@ -326,6 +330,9 @@ defmodule JSONRPC2.BridgeSyncMock do
       end
 
     {:reply, result, state}
+  end
+
+  def handle_call({:get_transaction_receipt, transacton_hash}, _, state = %{trie: trie}) do
   end
 
   @spec handle_call(:get_last_sync_block_stats, {pid, any}, map()) ::

--- a/apps/jsonrpc2/test/support/bridge_sync_mock.ex
+++ b/apps/jsonrpc2/test/support/bridge_sync_mock.ex
@@ -2,6 +2,7 @@ defmodule JSONRPC2.BridgeSyncMock do
   alias Blockchain.Account
   alias Blockchain.Block
   alias JSONRPC2.Response.Block, as: ResponseBlock
+  alias JSONRPC2.Response.Receipt, as: ResponseReceipt
   alias JSONRPC2.Response.Transaction, as: ResponseTransaction
   alias JSONRPC2.Struct.EthSyncing
   alias MerklePatriciaTree.TrieStorage
@@ -332,7 +333,14 @@ defmodule JSONRPC2.BridgeSyncMock do
     {:reply, result, state}
   end
 
-  def handle_call({:get_transaction_receipt, transacton_hash}, _, state = %{trie: trie}) do
+  def handle_call({:get_transaction_receipt, transaction_hash}, _, state = %{trie: trie}) do
+    result =
+      case Block.get_receipt_by_transaction_hash(transaction_hash, trie) do
+        {receipt, transaction, block} -> ResponseReceipt.new(receipt, transaction, block)
+        _ -> nil
+      end
+
+    {:reply, result, state}
   end
 
   @spec handle_call(:get_last_sync_block_stats, {pid, any}, map()) ::

--- a/apps/jsonrpc2/test/support/test_factory.ex
+++ b/apps/jsonrpc2/test/support/test_factory.ex
@@ -2,6 +2,8 @@ defmodule JSONRPC2.TestFactory do
   alias Block.Header
   alias Blockchain.Block
   alias Blockchain.Transaction
+  alias Blockchain.Transaction.Receipt
+  alias Blockchain.Transaction.Receipt.Bloom
 
   @empty_trie MerklePatriciaTree.Trie.empty_trie_root_hash()
 
@@ -68,5 +70,18 @@ defmodule JSONRPC2.TestFactory do
     args = Map.merge(defaults, opts)
 
     struct(Transaction, args)
+  end
+
+  def factory(:receipt, opts) do
+    defaults = %{
+      state: 1,
+      cumulative_gas: 1_000,
+      bloom_filter: :binary.list_to_bin(Bloom.empty()),
+      logs: []
+    }
+
+    args = Map.merge(defaults, opts)
+
+    struct(Receipt, args)
   end
 end


### PR DESCRIPTION
Changes:
- Implement `eth_getTransactionReceipt` 

Next PRs:
- encode logs
- encode created contract address for contract creation transactions