### PR TITLE
Uncle getter methods for JSON RPC API

### DIFF
--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -224,7 +224,7 @@ defmodule JSONRPC2.Bridge.Sync do
   def get_uncle_by_block_number_and_index(block_number, index) do
     trie = get_last_sync_state().trie
 
-    case Block.get_block(block_index, trie) do
+    case Block.get_block(block_number, trie) do
       {:ok, block} ->
         case Enum.at(block.ommers, index) do
           nil ->

--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -198,4 +198,50 @@ defmodule JSONRPC2.Bridge.Sync do
       nil -> nil
     end
   end
+
+  def get_uncle_by_block_hash_and_index(block_hash, index) do
+    trie = get_last_sync_state().trie
+
+    result =
+      case Block.get_block(block_hash, trie) do
+        {:ok, block} ->
+          case Enum.at(block.ommers, index) do
+            nil ->
+              nil
+
+            ommer_header ->
+              uncle_block = %Block{header: ommer_header, transactions: [], ommers: []}
+
+              uncle_block
+              |> Block.add_metadata(trie)
+              |> ResponseBlock.new()
+          end
+
+        _ ->
+          nil
+      end
+  end
+
+  def get_uncle_by_block_index_and_index(block_index, index) do
+    trie = get_last_sync_state().trie
+
+    result =
+      case Block.get_block(block_index, trie) do
+        {:ok, block} ->
+          case Enum.at(block.ommers, index) do
+            nil ->
+              nil
+
+            ommer_header ->
+              uncle_block = %Block{header: ommer_header, transactions: [], ommers: []}
+
+              uncle_block
+              |> Block.add_metadata(trie)
+              |> ResponseBlock.new()
+          end
+
+        _ ->
+          nil
+      end
+  end
 end

--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -202,46 +202,44 @@ defmodule JSONRPC2.Bridge.Sync do
   def get_uncle_by_block_hash_and_index(block_hash, index) do
     trie = get_last_sync_state().trie
 
-    result =
-      case Block.get_block(block_hash, trie) do
-        {:ok, block} ->
-          case Enum.at(block.ommers, index) do
-            nil ->
-              nil
+    case Block.get_block(block_hash, trie) do
+      {:ok, block} ->
+        case Enum.at(block.ommers, index) do
+          nil ->
+            nil
 
-            ommer_header ->
-              uncle_block = %Block{header: ommer_header, transactions: [], ommers: []}
+          ommer_header ->
+            uncle_block = %Block{header: ommer_header, transactions: [], ommers: []}
 
-              uncle_block
-              |> Block.add_metadata(trie)
-              |> ResponseBlock.new()
-          end
+            uncle_block
+            |> Block.add_metadata(trie)
+            |> ResponseBlock.new()
+        end
 
-        _ ->
-          nil
-      end
+      _ ->
+        nil
+    end
   end
 
   def get_uncle_by_block_index_and_index(block_index, index) do
     trie = get_last_sync_state().trie
 
-    result =
-      case Block.get_block(block_index, trie) do
-        {:ok, block} ->
-          case Enum.at(block.ommers, index) do
-            nil ->
-              nil
+    case Block.get_block(block_index, trie) do
+      {:ok, block} ->
+        case Enum.at(block.ommers, index) do
+          nil ->
+            nil
 
-            ommer_header ->
-              uncle_block = %Block{header: ommer_header, transactions: [], ommers: []}
+          ommer_header ->
+            uncle_block = %Block{header: ommer_header, transactions: [], ommers: []}
 
-              uncle_block
-              |> Block.add_metadata(trie)
-              |> ResponseBlock.new()
-          end
+            uncle_block
+            |> Block.add_metadata(trie)
+            |> ResponseBlock.new()
+        end
 
-        _ ->
-          nil
-      end
+      _ ->
+        nil
+    end
   end
 end

--- a/apps/jsonrpc2/lib/bridge/sync.ex
+++ b/apps/jsonrpc2/lib/bridge/sync.ex
@@ -221,7 +221,7 @@ defmodule JSONRPC2.Bridge.Sync do
     end
   end
 
-  def get_uncle_by_block_index_and_index(block_index, index) do
+  def get_uncle_by_block_number_and_index(block_number, index) do
     trie = get_last_sync_state().trie
 
     case Block.get_block(block_index, trie) do

--- a/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
@@ -149,7 +149,13 @@ defmodule JSONRPC2.SpecHandler do
     @sync.get_transaction_receipt(transaction_hash)
   end
 
-  def handle_request("eth_getUncleByBlockHashAndIndex", _), do: {:error, :not_supported}
+  def handle_request("eth_getUncleByBlockHashAndIndex", [hex_block_hash, hex_index]) do
+    block_hash = Exth.decode_hex(hex_block_hash)
+    index = Exth.decode_unsigned_from_hex(hex_index)
+
+    @sync.get_uncle_by_block_hash_and_index(block_hash, index)
+  end
+
   def handle_request("eth_getUncleByBlockNumberAndIndex", _), do: {:error, :not_supported}
   # eth_getCompilers is deprecated
   def handle_request("eth_getCompilers", _), do: {:error, :not_supported}

--- a/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
+++ b/apps/jsonrpc2/lib/jsonrpc2/spec_handler.ex
@@ -156,7 +156,13 @@ defmodule JSONRPC2.SpecHandler do
     @sync.get_uncle_by_block_hash_and_index(block_hash, index)
   end
 
-  def handle_request("eth_getUncleByBlockNumberAndIndex", _), do: {:error, :not_supported}
+  def handle_request("eth_getUncleByBlockNumberAndIndex", [hex_block_number, hex_index]) do
+    block_number = Exth.decode_unsigned_from_hex(hex_block_number)
+    index = Exth.decode_unsigned_from_hex(hex_index)
+
+    @sync.get_uncle_by_block_number_and_index(block_number, index)
+  end
+
   # eth_getCompilers is deprecated
   def handle_request("eth_getCompilers", _), do: {:error, :not_supported}
   # eth_compileLLL is deprecated

--- a/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
@@ -535,6 +535,32 @@ defmodule JSONRPC2.ManaHandlerTest do
     end
   end
 
+  describe "eth_getUncleByBlockHashAndIndex" do
+    test "fetches uncle by block hash and index" do
+      uncles = [
+        TestFactory.build(:header),
+        TestFactory.build(:header),
+        TestFactory.build(:header),
+        TestFactory.build(:header)
+      ]
+
+      block =
+        TestFactory.build(:block,
+          block_hash: <<0x113::256>>,
+          header: TestFactory.build(:header, number: 1110),
+          ommers: uncles
+        )
+
+      :ok = BridgeSyncMock.put_block(block)
+
+      assert_rpc_reply(
+        SpecHandler,
+        ~s({"jsonrpc": "2.0", "method": "eth_getUncleByBlockHashAndIndex", "params": ["0x0000000000000000000000000000000000000000000000000000000000000113", "0x03"], "id": 71}),
+        ~s({"id":71, "jsonrpc":"2.0", "result":{"difficulty":"0x01", "extraData":"", "gasLimit":"0x00", "gasUsed":"0x00", "hash":"0xa33912876669bdef5f8e9bcd54b32864c2cd6af57370f06dd17472942c5728a5", "logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "miner":"0x0000000000000000000000000000000000000010", "nonce":"0x0000000000000000", "number":"0x01", "parentHash":"0x0000000000000000000000000000000000000000000000000000000000000010", "receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421", "sha3Uncles":"0x0000000000000000000000000000000000000000000000000000000000000010", "size":"0x01f5", "stateRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421", "timestamp":"0x01", "totalDifficulty":"0x01", "transactions":[], "transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421", "uncles":[]}})
+      )
+    end
+  end
+
   defp assert_rpc_reply(handler, call, expected_reply) do
     assert {:reply, reply} = handler.handle(call)
 

--- a/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
+++ b/apps/jsonrpc2/test/jsonrpc2/mana_handler_test.exs
@@ -561,6 +561,32 @@ defmodule JSONRPC2.ManaHandlerTest do
     end
   end
 
+  describe "eth_getUncleByBlockNumberAndIndex" do
+    test "fetches uncle by block hash and index" do
+      uncles = [
+        TestFactory.build(:header),
+        TestFactory.build(:header),
+        TestFactory.build(:header),
+        TestFactory.build(:header)
+      ]
+
+      block =
+        TestFactory.build(:block,
+          block_hash: <<0x119::256>>,
+          header: TestFactory.build(:header, number: 1117),
+          ommers: uncles
+        )
+
+      :ok = BridgeSyncMock.put_block(block)
+
+      assert_rpc_reply(
+        SpecHandler,
+        ~s({"jsonrpc": "2.0", "method": "eth_getUncleByBlockNumberAndIndex", "params": ["0x045d", "0x03"], "id": 71}),
+        ~s({"id":71, "jsonrpc":"2.0", "result":{"difficulty":"0x01", "extraData":"", "gasLimit":"0x00", "gasUsed":"0x00", "hash":"0xa33912876669bdef5f8e9bcd54b32864c2cd6af57370f06dd17472942c5728a5", "logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "miner":"0x0000000000000000000000000000000000000010", "nonce":"0x0000000000000000", "number":"0x01", "parentHash":"0x0000000000000000000000000000000000000000000000000000000000000010", "receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421", "sha3Uncles":"0x0000000000000000000000000000000000000000000000000000000000000010", "size":"0x01f5", "stateRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421", "timestamp":"0x01", "totalDifficulty":"0x01", "transactions":[], "transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421", "uncles":[]}})
+      )
+    end
+  end
+
   defp assert_rpc_reply(handler, call, expected_reply) do
     assert {:reply, reply} = handler.handle(call)
 

--- a/apps/jsonrpc2/test/support/bridge_sync_mock.ex
+++ b/apps/jsonrpc2/test/support/bridge_sync_mock.ex
@@ -98,7 +98,11 @@ defmodule JSONRPC2.BridgeSyncMock do
   end
 
   def get_uncle_by_block_hash_and_index(block_hash, index) do
-    GenServer.call(__MODULE__, {:get_uncle_by_block_hash_and_index, {block_hash, index}})
+    GenServer.call(__MODULE__, {:get_uncle_by_block_and_index, {block_hash, index}})
+  end
+
+  def get_uncle_by_block_number_and_index(block_number, index) do
+    GenServer.call(__MODULE__, {:get_uncle_by_block_and_index, {block_number, index}})
   end
 
   def get_transaction_by_hash(transaction_hash) do
@@ -289,12 +293,12 @@ defmodule JSONRPC2.BridgeSyncMock do
   end
 
   def handle_call(
-        {:get_uncle_by_block_hash_and_index, {block_hash, index}},
+        {:get_uncle_by_block_and_index, {block_hash_or_index, index}},
         _,
         state = %{trie: trie}
       ) do
     result =
-      case Block.get_block(block_hash, trie) do
+      case Block.get_block(block_hash_or_index, trie) do
         {:ok, block} ->
           case Enum.at(block.ommers, index) do
             nil ->


### PR DESCRIPTION
Changes:
- implement `eth_getUncleByBlockHashAndIndex`
- implement `eth_getUncleByBlockIndexAndIndex`