### PR TITLE
handle not found blocks in RPC client

### DIFF
--- a/apps/cli/lib/block_provider/rpc.ex
+++ b/apps/cli/lib/block_provider/rpc.ex
@@ -148,6 +148,9 @@ defmodule CLI.BlockProvider.RPC do
   @spec load_new_block(integer(), ethereumex_client(), integer()) :: {:ok, %{}} | {:error, any()}
   defp load_new_block(number, client, retries \\ @max_retries) do
     case client.eth_get_block_by_number(to_hex(number), true) do
+      {:ok, nil} ->
+        {:error, :not_found}
+
       {:ok, block} ->
         {:ok, block}
 


### PR DESCRIPTION
Currently, the sync is failing when a block is not found using RPC client
```
(BadMapError) expected a map, got: nil  
    (elixir) lib/map.ex:437: Map.get(nil, "hash", nil)
    lib/block_provider/rpc.ex:185: CLI.BlockProvider.RPC.get/4
    lib/block_provider/rpc.ex:71: CLI.BlockProvider.RPC.get_block/2
    lib/sync.ex:45: CLI.Sync.sync_new_blocks/8
```